### PR TITLE
Loggers created with main class, not nested compiler generated class

### DIFF
--- a/Common/CecilExtensions.cs
+++ b/Common/CecilExtensions.cs
@@ -191,4 +191,9 @@ public static class CecilExtensions
 
         return definition;
     }
+
+    public static bool IsCompilerGenerated(this ICustomAttributeProvider value)
+    {
+        return value.CustomAttributes.Any(a => a.AttributeType.Name == "CompilerGeneratedAttribute");
+    }
 }

--- a/CustomAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
+++ b/CustomAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using Anotar.Custom;
+
+public class ClassWithCompilerGeneratedClasses
+{
+    public async void AsyncMethod()
+    {
+        Log.Debug("Foo");
+    }
+
+    public IEnumerable<int> EnumeratorMethod()
+    {
+        yield return 1;
+        Log.Debug("Foo");
+        yield return 2;
+    }
+
+    public void DelegateMethod()
+    {
+        Action action = () => Log.Debug("Foo");
+        action();
+    }
+
+    public void LambdaMethod()
+    {
+        int x = 0;
+        Action<string> log = l => Log.Debug(l, x);
+        log("Foo {0}");
+    }
+}

--- a/CustomAssemblyToProcess/ClassWithLogging.cs
+++ b/CustomAssemblyToProcess/ClassWithLogging.cs
@@ -3,10 +3,6 @@ using Anotar.Custom;
 
 public class ClassWithLogging
 {
-    public async void AsyncMethod()
-    {
-        System.Diagnostics.Trace.WriteLine("Foo");
-    }
     public void Debug()
     {
         Log.Debug();

--- a/CustomAssemblyToProcess/CustomAssemblyToProcess.csproj
+++ b/CustomAssemblyToProcess/CustomAssemblyToProcess.csproj
@@ -58,6 +58,7 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="ClassWithAbstract.cs" />
+    <Compile Include="ClassWithCompilerGeneratedClasses.cs" />
     <Compile Include="ClassWithExistingField_NLog.cs" />
     <Compile Include="ClassWithLogging.cs" />
     <Compile Include="ClassWithMultipleLoggings.cs" />

--- a/CustomFody/TypeProcessor.cs
+++ b/CustomFody/TypeProcessor.cs
@@ -64,7 +64,16 @@ public partial class ModuleWeaver
         var staticConstructor = type.GetStaticConstructor();
         staticConstructor.Body.SimplifyMacros();
         var genericInstanceMethod = new GenericInstanceMethod(GetLoggerMethod);
-        genericInstanceMethod.GenericArguments.Add(type.GetGeneric());
+
+        if (type.IsCompilerGenerated() && type.IsNested)
+        {
+            genericInstanceMethod.GenericArguments.Add(type.DeclaringType.GetGeneric());
+        }
+        else
+        {
+            genericInstanceMethod.GenericArguments.Add(type.GetGeneric());
+        }
+
         var instructions = staticConstructor.Body.Instructions;
         type.Fields.Add(fieldDefinition);
 

--- a/Log4NetAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
+++ b/Log4NetAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using Anotar.Log4Net;
+
+public class ClassWithCompilerGeneratedClasses
+{
+    public async void AsyncMethod()
+    {
+        Log.Debug("Foo");
+    }
+
+    public IEnumerable<int> EnumeratorMethod()
+    {
+        yield return 1;
+        Log.Debug("Foo");
+        yield return 2;
+    }
+
+    public void DelegateMethod()
+    {
+        Action action = () => Log.Debug("Foo");
+        action();
+    }
+
+    public void LambdaMethod()
+    {
+        int x = 0;
+        Action<string> log = l => Log.Debug(l, x);
+        log("Foo {0}");
+    }
+}

--- a/Log4NetAssemblyToProcess/ClassWithLogging.cs
+++ b/Log4NetAssemblyToProcess/ClassWithLogging.cs
@@ -4,10 +4,6 @@ using Anotar.Log4Net;
 
 public class ClassWithLogging
 {
-    public async void AsyncMethod()
-    {
-        Trace.WriteLine("Foo");
-    }
     public void Debug()
     {
         Log.Debug();

--- a/Log4NetAssemblyToProcess/Log4NetAssemblyToProcess.csproj
+++ b/Log4NetAssemblyToProcess/Log4NetAssemblyToProcess.csproj
@@ -60,6 +60,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ClassWithAbstract.cs" />
+    <Compile Include="ClassWithCompilerGeneratedClasses.cs" />
     <Compile Include="ClassWithLogging.cs" />
     <Compile Include="ClassWithExistingField.cs" />
     <Compile Include="ClassWithMultipleLoggings.cs" />

--- a/Log4NetFody/TypeProcessor.cs
+++ b/Log4NetFody/TypeProcessor.cs
@@ -61,7 +61,13 @@ public partial class ModuleWeaver
 		var staticConstructor = type.GetStaticConstructor();
 	    var instructions = staticConstructor.Body.Instructions;
 
-	    instructions.Insert(0, Instruction.Create(OpCodes.Ldstr, type.FullName));
+        var logName = type.FullName;
+        if (type.IsCompilerGenerated() && type.IsNested)
+        {
+            logName = type.DeclaringType.FullName;
+        }
+
+        instructions.Insert(0, Instruction.Create(OpCodes.Ldstr, logName));
 	    instructions.Insert(1, Instruction.Create(OpCodes.Call, buildLoggerMethod));
 	    instructions.Insert(2, Instruction.Create(OpCodes.Stsfld, fieldDefinition.GetGeneric()));
 	    type.Fields.Add(fieldDefinition);

--- a/MetroLogAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
+++ b/MetroLogAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using Anotar.MetroLog;
+
+public class ClassWithCompilerGeneratedClasses
+{
+    public async void AsyncMethod()
+    {
+        Log.Debug("Foo");
+    }
+
+    public IEnumerable<int> EnumeratorMethod()
+    {
+        yield return 1;
+        Log.Debug("Foo");
+        yield return 2;
+    }
+
+    public void DelegateMethod()
+    {
+        Action action = () => Log.Debug("Foo");
+        action();
+    }
+
+    public void LambdaMethod()
+    {
+        int x = 0;
+        Action<string> log = l => Log.Debug(l, x);
+        log("Foo {0}");
+    }
+}

--- a/MetroLogAssemblyToProcess/MetroLogAssemblyToProcess.csproj
+++ b/MetroLogAssemblyToProcess/MetroLogAssemblyToProcess.csproj
@@ -52,6 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ClassWithAbstract.cs" />
+    <Compile Include="ClassWithCompilerGeneratedClasses.cs" />
     <Compile Include="ClassWithLogging.cs" />
     <Compile Include="ClassWithExistingField.cs" />
     <Compile Include="ClassWithMultipleLoggings.cs" />

--- a/MetroLogFody/TypeProcessor.cs
+++ b/MetroLogFody/TypeProcessor.cs
@@ -61,8 +61,14 @@ public partial class ModuleWeaver
 		var staticConstructor = type.GetStaticConstructor();
 	    var instructions = staticConstructor.Body.Instructions;
 
+        var logName = type.FullName;
+        if (type.IsCompilerGenerated() && type.IsNested)
+        {
+            logName = type.DeclaringType.FullName;
+        }
+
 	    instructions.Insert(0, Instruction.Create(OpCodes.Call, getDefaultLogManager));
-	    instructions.Insert(1, Instruction.Create(OpCodes.Ldstr, type.FullName));
+        instructions.Insert(1, Instruction.Create(OpCodes.Ldstr, logName));
 	    instructions.Insert(2, Instruction.Create(OpCodes.Ldnull));
 	    instructions.Insert(3, Instruction.Create(OpCodes.Callvirt, buildLoggerMethod));
 	    instructions.Insert(4, Instruction.Create(OpCodes.Stsfld, fieldDefinition.GetGeneric()));

--- a/NLogAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
+++ b/NLogAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using Anotar.NLog;
+
+public class ClassWithCompilerGeneratedClasses
+{
+    public async void AsyncMethod()
+    {
+        Log.Debug("Foo");
+    }
+
+    public IEnumerable<int> EnumeratorMethod()
+    {
+        yield return 1;
+        Log.Debug("Foo");
+        yield return 2;
+    }
+
+    public void DelegateMethod()
+    {
+        Action action = () => Log.Debug("Foo");
+        action();
+    }
+
+    public void LambdaMethod()
+    {
+        int x = 0;
+        Action<string> log = l => Log.Debug(l, x);
+        log("Foo {0}");
+    }
+}

--- a/NLogAssemblyToProcess/ClassWithLogging.cs
+++ b/NLogAssemblyToProcess/ClassWithLogging.cs
@@ -3,10 +3,6 @@ using Anotar.NLog;
 
 public class ClassWithLogging
 {
-    public async void AsyncMethod()
-    {
-        System.Diagnostics.Trace.WriteLine("Foo");
-    }
     public void Trace()
     {
         Log.Trace();

--- a/NLogAssemblyToProcess/NLogAssemblyToProcess.csproj
+++ b/NLogAssemblyToProcess/NLogAssemblyToProcess.csproj
@@ -61,6 +61,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ClassWithAbstract.cs" />
+    <Compile Include="ClassWithCompilerGeneratedClasses.cs" />
     <Compile Include="ClassWithExistingField_NLog.cs" />
     <Compile Include="ClassWithLogging.cs" />
     <Compile Include="ClassWithMultipleLoggings.cs" />

--- a/NLogFody/TypeProcessor.cs
+++ b/NLogFody/TypeProcessor.cs
@@ -62,14 +62,20 @@ public partial class ModuleWeaver
 		var staticConstructor = type.GetStaticConstructor();
 		var instructions = staticConstructor.Body.Instructions;
 
-       if (type.HasGenericParameters)
+        if (type.HasGenericParameters)
         {
             instructions.Insert(0, Instruction.Create(OpCodes.Call, buildLoggerGenericMethod));
-			instructions.Insert(1, Instruction.Create(OpCodes.Stsfld, fieldDefinition.GetGeneric()));
+            instructions.Insert(1, Instruction.Create(OpCodes.Stsfld, fieldDefinition.GetGeneric()));
         }
         else
         {
-            instructions.Insert(0, Instruction.Create(OpCodes.Ldstr, type.FullName));
+            var logName = type.FullName;
+            if (type.IsCompilerGenerated() && type.IsNested)
+            {
+                logName = type.DeclaringType.FullName;
+            }
+
+            instructions.Insert(0, Instruction.Create(OpCodes.Ldstr, logName));
             instructions.Insert(1, Instruction.Create(OpCodes.Call, buildLoggerMethod));
             instructions.Insert(2, Instruction.Create(OpCodes.Stsfld, fieldDefinition));
         }

--- a/SerilogAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
+++ b/SerilogAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using Anotar.Serilog;
+
+public class ClassWithCompilerGeneratedClasses
+{
+    public async void AsyncMethod()
+    {
+        Log.Debug("Foo");
+    }
+
+    public IEnumerable<int> EnumeratorMethod()
+    {
+        yield return 1;
+        Log.Debug("Foo");
+        yield return 2;
+    }
+
+    public void DelegateMethod()
+    {
+        Action action = () => Log.Debug("Foo");
+        action();
+    }
+
+    public void LambdaMethod()
+    {
+        int x = 0;
+        Action<string> log = l => Log.Debug(l, x);
+        log("Foo {0}");
+    }
+}

--- a/SerilogAssemblyToProcess/ClassWithLogging.cs
+++ b/SerilogAssemblyToProcess/ClassWithLogging.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Anotar.Serilog;
 

--- a/SerilogAssemblyToProcess/SerilogAssemblyToProcess.csproj
+++ b/SerilogAssemblyToProcess/SerilogAssemblyToProcess.csproj
@@ -58,6 +58,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ClassWithAbstract.cs" />
+    <Compile Include="ClassWithCompilerGeneratedClasses.cs" />
     <Compile Include="ClassWithExistingField.cs" />
     <Compile Include="ClassWithLogging.cs" />
     <Compile Include="ClassWithMultipleLoggings.cs" />

--- a/SerilogFody/TypeProcessor.cs
+++ b/SerilogFody/TypeProcessor.cs
@@ -63,7 +63,16 @@ public partial class ModuleWeaver
         var staticConstructor = type.GetStaticConstructor();
         staticConstructor.Body.SimplifyMacros();
         var genericInstanceMethod = new GenericInstanceMethod(forContextDefinition);
-        genericInstanceMethod.GenericArguments.Add(type.GetGeneric());
+
+        if (type.IsCompilerGenerated() && type.IsNested)
+        {
+            genericInstanceMethod.GenericArguments.Add(type.DeclaringType.GetGeneric());
+        }
+        else
+        {
+            genericInstanceMethod.GenericArguments.Add(type.GetGeneric());
+        }
+
         var instructions = staticConstructor.Body.Instructions;
         type.Fields.Add(fieldDefinition);
 


### PR DESCRIPTION
When using Anotar.NLog and logging the type in the log message we were getting a lot of logs like this.

```
SomeClass/<>c__DisplayClass8 [DEBUG] Log message
ClassWithStuff/<MethodWithYield>d_4 [DEBUG] LogMessage
```

These types are the compiler generated types from using lambdas, yields and async. This PR removes the compiler generated type and uses the original declaring type to create the logger.

This does not affect the log prefix that Anotar adds, so that still has the compiler generated type in the log message.
