### PR TITLE
Replacing instructions must update branch instructions too

### DIFF
--- a/CatelAssemblyToProcess/ClassWithMultipleLoggings.cs
+++ b/CatelAssemblyToProcess/ClassWithMultipleLoggings.cs
@@ -26,4 +26,14 @@ public class ClassWithMultipleLoggings
         LogTo.Info(new Exception(),"Info");
         LogTo.Warning(new Exception(), "Warn");
     }
+
+    public void LogThrowLog(bool dothrow)
+    {
+        LogTo.Info("Doing something");
+
+        if (dothrow)
+            throw new Exception();
+
+        LogTo.Info("Doing something");
+    }
 }

--- a/Common/CecilExtensions.cs
+++ b/Common/CecilExtensions.cs
@@ -8,6 +8,15 @@ public static class CecilExtensions
 {
     public static void Replace(this Collection<Instruction> collection, Instruction instruction, IEnumerable<Instruction> instructions)
     {
+        // Any instructions pointing to the instruction to be replaced
+        // need to point to the new instruction instead.
+        var newInstruction = instructions.First();
+        foreach (var item in collection)
+        {
+            if (item.Operand == instruction)
+                item.Operand = newInstruction;
+        }
+
         var indexOf = collection.IndexOf(instruction);
         collection.RemoveAt(indexOf);
         foreach (var instruction1 in instructions)

--- a/CustomAssemblyToProcess/ClassWithMultipleLoggings.cs
+++ b/CustomAssemblyToProcess/ClassWithMultipleLoggings.cs
@@ -26,4 +26,14 @@ public class ClassWithMultipleLoggings
         Log.Information(new Exception(), "Info");
         Log.Warning(new Exception(), "Warn");
     }
+
+    public void LogThrowLog(bool dothrow)
+    {
+        Log.Information("Doing something");
+
+        if (dothrow)
+            throw new Exception();
+
+        Log.Information("Doing something");
+    }
 }

--- a/Log4NetAssemblyToProcess/ClassWithMultipleLoggings.cs
+++ b/Log4NetAssemblyToProcess/ClassWithMultipleLoggings.cs
@@ -26,4 +26,14 @@ public class ClassWithMultipleLoggings
         Log.InfoException("Info", new Exception());
         Log.WarnException("Warn", new Exception());
     }
+
+    public void LogThrowLog(bool dothrow)
+    {
+        Log.Info("Doing something");
+
+        if (dothrow)
+            throw new Exception();
+
+        Log.Info("Doing something");
+    }
 }

--- a/MetroLogAssemblyToProcess/ClassWithMultipleLoggings.cs
+++ b/MetroLogAssemblyToProcess/ClassWithMultipleLoggings.cs
@@ -26,4 +26,14 @@ public class ClassWithMultipleLoggings
         Log.InfoException("Info", new Exception());
         Log.WarnException("Warn", new Exception());
     }
+
+    public void LogThrowLog(bool dothrow)
+    {
+        Log.Info("Doing something");
+
+        if (dothrow)
+            throw new Exception();
+
+        Log.Info("Doing something");
+    }
 }

--- a/NLogAssemblyToProcess/ClassWithMultipleLoggings.cs
+++ b/NLogAssemblyToProcess/ClassWithMultipleLoggings.cs
@@ -26,4 +26,14 @@ public class ClassWithMultipleLoggings
         Log.InfoException("Info", new Exception());
         Log.WarnException("Warn", new Exception());
     }
+
+    public void LogThrowLog(bool dothrow)
+    {
+        Log.Info("Doing something");
+
+        if (dothrow)
+            throw new Exception();
+
+        Log.Info("Doing something");
+    }
 }

--- a/SerilogAssemblyToProcess/ClassWithMultipleLoggings.cs
+++ b/SerilogAssemblyToProcess/ClassWithMultipleLoggings.cs
@@ -26,4 +26,14 @@ public class ClassWithMultipleLoggings
         LogTo.Information(new Exception(), "Info");
         LogTo.Warning(new Exception(), "Warn");
     }
+
+    public void LogThrowLog(bool dothrow)
+    {
+        LogTo.Information("Doing something");
+
+        if (dothrow)
+            throw new Exception();
+
+        LogTo.Information("Doing something");
+    }
 }


### PR DESCRIPTION
The issue was a branch instruction was pointing to an instruction that was then replaced, and the replace code was not updating the branch so when the whole thing was finally saved back out the branch pointed to an IL offset that no longer existed.
