### PR TITLE
Updated Anotar.CommonLogging.Fody to use Common.Logging 3.0.0.

### DIFF
--- a/CommonLoggingAssemblyToProcess/CommonLoggingAssemblyToProcess.csproj
+++ b/CommonLoggingAssemblyToProcess/CommonLoggingAssemblyToProcess.csproj
@@ -43,8 +43,12 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Common.Logging">
-      <HintPath>..\packages\Common.Logging.2.3.1\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Common.Logging.3.0.0\lib\net40\Common.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Common.Logging.Core">
+      <HintPath>..\packages\Common.Logging.Core.3.0.0\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/CommonLoggingAssemblyToProcess/packages.config
+++ b/CommonLoggingAssemblyToProcess/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Common.Logging" version="2.3.1" targetFramework="net45" />
+  <package id="Common.Logging" version="3.0.0" targetFramework="net45" />
+  <package id="Common.Logging.Core" version="3.0.0" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
 </packages>

--- a/CommonLoggingFody/Anotar.CommonLogging.nuspec
+++ b/CommonLoggingFody/Anotar.CommonLogging.nuspec
@@ -16,7 +16,7 @@
     <tags>Logging, ILWeaving, Fody, Cecil, Common.Logging</tags>
     <dependencies>
       <dependency id="Fody"/>
-      <dependency id="Common.Logging" version="3.0.0"/>		
+      <dependency id="Common.Logging.Portable" version="3.0.0"/>		
 	</dependencies>
   </metadata>
 </package>

--- a/CommonLoggingFody/Anotar.CommonLogging.nuspec
+++ b/CommonLoggingFody/Anotar.CommonLogging.nuspec
@@ -16,7 +16,7 @@
     <tags>Logging, ILWeaving, Fody, Cecil, Common.Logging</tags>
     <dependencies>
       <dependency id="Fody"/>
-      <dependency id="Common.Logging" version="2.3.1"/>		
+      <dependency id="Common.Logging" version="3.0.0"/>		
 	</dependencies>
   </metadata>
 </package>

--- a/CommonLoggingFody/CommonLoggingFody.csproj
+++ b/CommonLoggingFody/CommonLoggingFody.csproj
@@ -43,8 +43,12 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Common.Logging">
-      <HintPath>..\packages\Common.Logging.2.3.1\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Common.Logging.3.0.0\lib\net40\Common.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Common.Logging.Core">
+      <HintPath>..\packages\Common.Logging.Core.3.0.0\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.CSharp" />

--- a/CommonLoggingFody/ReferenceFinder.cs
+++ b/CommonLoggingFody/ReferenceFinder.cs
@@ -5,25 +5,27 @@ using Mono.Cecil;
 public partial class ModuleWeaver
 {
 	public Lazy<AssemblyDefinition> CommonLoggingReference;
+    public Lazy<AssemblyDefinition> CommonLoggingCoreReference;
 
 	void FindReference()
 	{
-        CommonLoggingReference = new Lazy<AssemblyDefinition>(GetCommonLogging);
+        CommonLoggingReference = new Lazy<AssemblyDefinition>(() => GetReference("Common.Logging"));
+        CommonLoggingCoreReference = new Lazy<AssemblyDefinition>(() => GetReference("Common.Logging.Core"));
 	}
 
-    AssemblyDefinition GetCommonLogging()
+    AssemblyDefinition GetReference(string referenceName)
     {
-        var existingReference = ModuleDefinition.AssemblyReferences.FirstOrDefault(x => x.Name == "Common.Logging");
+        var existingReference = ModuleDefinition.AssemblyReferences.FirstOrDefault(x => x.Name == referenceName);
 
         if (existingReference != null)
         {
             return AssemblyResolver.Resolve(existingReference);
         }
-        var reference = AssemblyResolver.Resolve("Common.Logging");
+        var reference = AssemblyResolver.Resolve(referenceName);
         if (reference != null)
         {
             return reference;
         }
-        throw new Exception("Could not resolve a reference to Common.Logging.dll.");
+        throw new Exception(string.Format("Could not resolve a reference to {0}.dll.", referenceName));
     }
 }

--- a/CommonLoggingFody/TestHelpers/ActionLog.cs
+++ b/CommonLoggingFody/TestHelpers/ActionLog.cs
@@ -373,4 +373,14 @@ public class ActionLog : ILog
     public bool IsFatalEnabled { get { return true; } }
     public bool IsInfoEnabled { get { return true; } }
     public bool IsWarnEnabled { get { return true; } }
+
+    public IVariablesContext GlobalVariablesContext
+    {
+        get { throw new NotImplementedException(); }
+    }
+
+    public IVariablesContext ThreadVariablesContext
+    {
+        get { throw new NotImplementedException(); }
+    }
 }

--- a/CommonLoggingFody/TypeResolver.cs
+++ b/CommonLoggingFody/TypeResolver.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Linq;
 using Mono.Cecil;
 
@@ -12,7 +13,8 @@ public partial class ModuleWeaver
         var getLoggerDefinition = logManagerType.Methods.First(x => x.Name == "GetLogger" && x.IsMatch("String"));
         constructLoggerMethod = ModuleDefinition.Import(getLoggerDefinition);
 
-        var loggerTypeDefinition = CommonLoggingReference.Value.MainModule.Types.First(x => x.Name == "ILog");
+        var types = CommonLoggingCoreReference.Value.MainModule.Types.ToArray();
+        var loggerTypeDefinition = CommonLoggingCoreReference.Value.MainModule.Types.First(x => x.Name == "ILog");
 
         DebugMethod = ModuleDefinition.Import(loggerTypeDefinition.FindMethod("DebugFormat", "String", "Object[]"));
 		isDebugEnabledMethod = ModuleDefinition.Import(loggerTypeDefinition.FindMethod("get_IsDebugEnabled"));

--- a/CommonLoggingFody/packages.config
+++ b/CommonLoggingFody/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Caseless.Fody" version="1.3.3.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Common.Logging" version="2.3.1" targetFramework="net45" />
+  <package id="Common.Logging" version="3.0.0" targetFramework="net45" />
+  <package id="Common.Logging.Core" version="3.0.0" targetFramework="net45" />
   <package id="Fody" version="1.26.4" targetFramework="net45" developmentDependency="true" />
   <package id="FodyCecil" version="1.26.4" targetFramework="net45" developmentDependency="true" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />


### PR DESCRIPTION
- Updated Common.Logging NuGet package to 3.0.0.
- Updated Anotor.CommonLogging.nuspec's Common.Logging dependency to 3.0.0.
- Fixed code to handle ILog moving from Common.Logging to Common.Logging.Core.