### PR TITLE
Async delegate

### DIFF
--- a/CatelAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
+++ b/CatelAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
@@ -29,4 +29,10 @@ public class ClassWithCompilerGeneratedClasses
         Action<string> log = l => LogTo.Debug(l, x);
         log("Foo {0}");
     }
+
+    public void AsyncDelegateMethod()
+    {
+        var action = new Action(async () => LogTo.Debug());
+        action();
+    }
 }

--- a/CatelFody/CatelTests.cs
+++ b/CatelFody/CatelTests.cs
@@ -26,7 +26,7 @@ public class CatelTests
 #endif
         afterAssemblyPath = WeaverHelper.Weave(beforeAssemblyPath);
         assembly = Assembly.LoadFile(afterAssemblyPath);
-        
+
         LogManager.AddListener(new LogListener
                                {
                                    Action =LogMessage
@@ -55,7 +55,7 @@ public class CatelTests
             Debugs.Add(message);
 // ReSharper disable once RedundantJumpStatement
             return;
-        }        
+        }
 
     }
 
@@ -198,7 +198,7 @@ public class CatelTests
     {
         var type = assembly.GetType("OnException");
         var instance = (dynamic)Activator.CreateInstance(type);
-     
+
         Assert.AreEqual("a",instance.MethodThatReturns("x", 6));
     }
 
@@ -455,13 +455,13 @@ public class CatelTests
         Assert.AreEqual(1, Errors.Count);
         Assert.IsTrue(Errors.First().StartsWith("Method: 'void ErrorStringExceptionFunc()'. Line: ~"));
     }
-    
+
     [Test]
     public void PeVerify()
     {
         Verifier.Verify(beforeAssemblyPath,afterAssemblyPath);
     }
-    
+
     [Test]
     public void AsyncMethod()
     {
@@ -489,6 +489,16 @@ public class CatelTests
         instance.DelegateMethod();
         Assert.AreEqual(1, Debugs.Count);
         Assert.IsTrue(Debugs.First().StartsWith("Method: 'Void DelegateMethod()'. Line: ~"), Debugs.First());
+    }
+
+    [Test]
+    public void AsyncDelegateMethod()
+    {
+        var type = assembly.GetType("ClassWithCompilerGeneratedClasses");
+        var instance = (dynamic)Activator.CreateInstance(type);
+        instance.AsyncDelegateMethod();
+        Assert.AreEqual(1, Debugs.Count);
+        Assert.IsTrue(Debugs.First().StartsWith("Method: 'Void AsyncDelegateMethod()'. Line: ~"), Debugs.First());
     }
 
     [Test]

--- a/CatelFody/TypeProcessor.cs
+++ b/CatelFody/TypeProcessor.cs
@@ -64,15 +64,7 @@ public partial class ModuleWeaver
         staticConstructor.Body.SimplifyMacros();
         var instructions = staticConstructor.Body.Instructions;
 
-        TypeReference declaringType;
-        if (type.IsCompilerGenerated() && type.IsNested)
-        {
-            declaringType = type.DeclaringType.GetGeneric();
-        }
-        else
-        {
-            declaringType = type.GetGeneric();
-        }
+        TypeReference declaringType = type.GetNonCompilerGeneratedType().GetGeneric();
 
         instructions.Insert(0, Instruction.Create(OpCodes.Ldtoken, declaringType));
         instructions.Insert(1, Instruction.Create(OpCodes.Call, GetTypeFromHandle));

--- a/Common/CecilExtensions.cs
+++ b/Common/CecilExtensions.cs
@@ -46,12 +46,7 @@ public static class CecilExtensions
         var isTypeCompilerGenerated = method.DeclaringType.IsCompilerGenerated();
         if (isTypeCompilerGenerated)
         {
-            var rootType = method.DeclaringType.DeclaringType;
-            while (rootType.DeclaringType != null && rootType.IsCompilerGenerated())
-            {
-                rootType = rootType.DeclaringType;
-            }
-
+            var rootType = method.DeclaringType.GetNonCompilerGeneratedType();
             if (rootType != null)
             {
                 foreach (var parentClassMethod in rootType.Methods)
@@ -80,6 +75,15 @@ public static class CecilExtensions
             }
         }
         return method;
+    }
+
+    public static TypeDefinition GetNonCompilerGeneratedType(this TypeDefinition typeDefinition)
+    {
+        while (typeDefinition.IsCompilerGenerated() && typeDefinition.DeclaringType != null)
+        {
+            typeDefinition = typeDefinition.DeclaringType;
+        }
+        return typeDefinition;
     }
 
     public static bool IsCompilerGenerated(this ICustomAttributeProvider value)

--- a/Common/CecilExtensions.cs
+++ b/Common/CecilExtensions.cs
@@ -47,11 +47,16 @@ public static class CecilExtensions
         if (isTypeCompilerGenerated)
         {
             var rootType = method.DeclaringType.DeclaringType;
+            while (rootType.DeclaringType != null && rootType.IsCompilerGenerated())
+            {
+                rootType = rootType.DeclaringType;
+            }
+
             if (rootType != null)
             {
                 foreach (var parentClassMethod in rootType.Methods)
                 {
-                    if (method.DeclaringType.Name.StartsWith("<" + parentClassMethod.Name + ">"))
+                    if (method.DeclaringType.Name.Contains("<" + parentClassMethod.Name + ">"))
                     {
                         return parentClassMethod;
                     }
@@ -80,6 +85,12 @@ public static class CecilExtensions
     public static bool IsCompilerGenerated(this ICustomAttributeProvider value)
     {
         return value.CustomAttributes.Any(a => a.AttributeType.Name == "CompilerGeneratedAttribute");
+    }
+
+    public static bool IsCompilerGenerated(this TypeDefinition typeDefinition)
+    {
+        return typeDefinition.CustomAttributes.Any(a => a.AttributeType.Name == "CompilerGeneratedAttribute") ||
+            (typeDefinition.IsNested && typeDefinition.DeclaringType.IsCompilerGenerated());
     }
 
     public static void CheckForInvalidLogToUsages(this MethodDefinition methodDefinition)

--- a/CommonLoggingAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
+++ b/CommonLoggingAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
@@ -28,4 +28,10 @@ public class ClassWithCompilerGeneratedClasses
         Action<string> log = l => LogTo.Debug(l, x);
         log("Foo {0}");
     }
+
+    public void AsyncDelegateMethod()
+    {
+        var action = new Action(async () => LogTo.Debug());
+        action();
+    }
 }

--- a/CommonLoggingFody/TypeProcessor.cs
+++ b/CommonLoggingFody/TypeProcessor.cs
@@ -61,11 +61,7 @@ public partial class ModuleWeaver
 		var staticConstructor = type.GetStaticConstructor();
 	    var instructions = staticConstructor.Body.Instructions;
 
-        var logName = type.FullName;
-        if (type.IsCompilerGenerated() && type.IsNested)
-        {
-            logName = type.DeclaringType.FullName;
-        }
+        var logName = type.GetNonCompilerGeneratedType().FullName;
 
         instructions.Insert(0, Instruction.Create(OpCodes.Ldstr, logName));
 	    instructions.Insert(1, Instruction.Create(OpCodes.Call, constructLoggerMethod));

--- a/CommonLoggingStandardTests/CommonLoggingTests.cs
+++ b/CommonLoggingStandardTests/CommonLoggingTests.cs
@@ -743,6 +743,17 @@ public class CommonLoggingTests
     }
 
     [Test]
+    public void AsyncDelegateMethod()
+    {
+        var type = assembly.GetType("ClassWithCompilerGeneratedClasses");
+        var instance = (dynamic)Activator.CreateInstance(type);
+        instance.AsyncDelegateMethod();
+        Assert.AreEqual(1, actionAdapter.Debugs.Count);
+        var logEvent = actionAdapter.Debugs.First();
+        Assert.IsTrue(logEvent.Format.StartsWith("Method: 'Void AsyncDelegateMethod()'. Line: ~"), logEvent.Format);
+    }
+
+    [Test]
     public void LambdaMethod()
     {
         var type = assembly.GetType("ClassWithCompilerGeneratedClasses");

--- a/CustomAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
+++ b/CustomAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
@@ -29,4 +29,10 @@ public class ClassWithCompilerGeneratedClasses
         Action<string> log = l => LogTo.Debug(l, x);
         log("Foo {0}");
     }
+
+    public void AsyncDelegateMethod()
+    {
+        var action = new Action(async () => LogTo.Debug());
+        action();
+    }
 }

--- a/CustomFody/CustomTests.cs
+++ b/CustomFody/CustomTests.cs
@@ -41,7 +41,7 @@ public class CustomTests
         var message = LoggerFactory.DebugEntries.First();
         Assert.IsTrue(message.Format.StartsWith("Method: 'void Debug()'. Line: ~"));
     }
-    
+
     [Test]
     public void EnsureLoggerFactoryAttributeisRemoved()
     {
@@ -185,7 +185,7 @@ public class CustomTests
         Action<dynamic> action = o => o.ToFatalWithReturn("x", 6);
         CheckException(action, LoggerFactory.FatalEntries, expected);
     }
-    
+
     [Test]
     public void IsTraceEnabled()
     {
@@ -516,7 +516,7 @@ public class CustomTests
         var instance = (dynamic)Activator.CreateInstance(type);
         Assert.IsTrue(instance.IsFatalEnabled());
     }
-    
+
     [Test]
     public void Fatal()
     {
@@ -576,13 +576,13 @@ public class CustomTests
         Assert.AreEqual(1, LoggerFactory.FatalEntries.Count);
         Assert.IsTrue(LoggerFactory.FatalEntries.First().Format.StartsWith("Method: 'void FatalStringExceptionFunc()'. Line: ~"));
     }
-    
+
     [Test]
     public void PeVerify()
     {
         Verifier.Verify(beforeAssemblyPath,afterAssemblyPath);
     }
-    
+
     [Test]
     public void AsyncMethod()
     {
@@ -610,6 +610,16 @@ public class CustomTests
         instance.DelegateMethod();
         var message = LoggerFactory.DebugEntries.First().Format;
         Assert.IsTrue(message.StartsWith("Method: 'Void DelegateMethod()'. Line: ~"), message);
+    }
+
+    [Test]
+    public void AsyncDelegateMethod()
+    {
+        var type = assembly.GetType("ClassWithCompilerGeneratedClasses");
+        var instance = (dynamic)Activator.CreateInstance(type);
+        instance.AsyncDelegateMethod();
+        var message = LoggerFactory.DebugEntries.First().Format;
+        Assert.IsTrue(message.StartsWith("Method: 'Void AsyncDelegateMethod()'. Line: ~"), message);
     }
 
     [Test]

--- a/CustomFody/TypeProcessor.cs
+++ b/CustomFody/TypeProcessor.cs
@@ -64,14 +64,7 @@ public partial class ModuleWeaver
         var staticConstructor = type.GetStaticConstructor();
         staticConstructor.Body.SimplifyMacros();
         var genericInstanceMethod = new GenericInstanceMethod(GetLoggerMethod);
-        if (type.IsCompilerGenerated() && type.IsNested)
-        {
-            genericInstanceMethod.GenericArguments.Add(type.DeclaringType.GetGeneric());
-        }
-        else
-        {
-            genericInstanceMethod.GenericArguments.Add(type.GetGeneric());
-        }
+        genericInstanceMethod.GenericArguments.Add(type.GetNonCompilerGeneratedType().GetGeneric());
         var instructions = staticConstructor.Body.Instructions;
         type.Fields.Add(fieldDefinition);
 

--- a/LibLogAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
+++ b/LibLogAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
@@ -28,4 +28,10 @@ public class ClassWithCompilerGeneratedClasses
         Action<string> log = l => LogTo.Debug(l, x);
         log("Foo {0}");
     }
+
+    public void AsyncDelegateMethod()
+    {
+        var action = new Action(async () => LogTo.Debug());
+        action();
+    }
 }

--- a/LibLogFody/LibLogTests.cs
+++ b/LibLogFody/LibLogTests.cs
@@ -617,6 +617,15 @@ public class LibLogTests
         Assert.IsTrue(logProvider.Debugs.First().StartsWith("Method: 'Void DelegateMethod()'. Line: ~"), logProvider.Debugs.First());
     }
     [Test]
+    public void AsyncDelegateMethod()
+    {
+        var type = assembly.GetType("ClassWithCompilerGeneratedClasses");
+        var instance = (dynamic)Activator.CreateInstance(type);
+        instance.AsyncDelegateMethod();
+        Assert.AreEqual(1, logProvider.Debugs.Count);
+        Assert.IsTrue(logProvider.Debugs.First().StartsWith("Method: 'Void AsyncDelegateMethod()'. Line: ~"), logProvider.Debugs.First());
+    }
+    [Test]
     public void LambdaMethod()
     {
         var type = assembly.GetType("ClassWithCompilerGeneratedClasses");

--- a/LibLogFody/TypeProcessor.cs
+++ b/LibLogFody/TypeProcessor.cs
@@ -59,11 +59,7 @@ public partial class ModuleWeaver
 
     void InjectField(TypeDefinition type, FieldDefinition fieldDefinition)
     {
-        var logName = type.FullName;
-        if (type.IsCompilerGenerated() && type.IsNested)
-        {
-            logName = type.DeclaringType.FullName;
-        }
+        var logName = type.GetNonCompilerGeneratedType().FullName;
         var staticConstructor = type.GetStaticConstructor();
         var instructions = staticConstructor.Body.Instructions;
         instructions.Insert(0, Instruction.Create(OpCodes.Ldstr, logName));

--- a/Log4NetAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
+++ b/Log4NetAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
@@ -28,4 +28,10 @@ public class ClassWithCompilerGeneratedClasses
         Action<string> log = l => LogTo.Debug(l, x);
         log("Foo {0}");
     }
+
+    public void AsyncDelegateMethod()
+    {
+        var action = new Action(async () => LogTo.Debug());
+        action();
+    }
 }

--- a/Log4NetFody/Log4NetTests.cs
+++ b/Log4NetFody/Log4NetTests.cs
@@ -31,7 +31,7 @@ public class Log4NetTests
         afterAssemblyPath = WeaverHelper.Weave(beforeAssemblyPath);
         assembly = Assembly.LoadFile(afterAssemblyPath);
         var hierarchy = (Hierarchy)LogManager.GetRepository();
-        hierarchy.Root.RemoveAllAppenders(); 
+        hierarchy.Root.RemoveAllAppenders();
 
         var target = new ActionAppender
         {
@@ -548,7 +548,7 @@ public class Log4NetTests
     {
         Verifier.Verify(beforeAssemblyPath,afterAssemblyPath);
     }
-    
+
     [Test]
     public void AsyncMethod()
     {
@@ -577,6 +577,16 @@ public class Log4NetTests
         instance.DelegateMethod();
         Assert.AreEqual(1, Debugs.Count);
         Assert.IsTrue(Debugs.First().StartsWith("Method: 'Void DelegateMethod()'. Line: ~"), Debugs.First());
+    }
+
+    [Test]
+    public void AsyncDelegateMethod()
+    {
+        var type = assembly.GetType("ClassWithCompilerGeneratedClasses");
+        var instance = (dynamic)Activator.CreateInstance(type);
+        instance.AsyncDelegateMethod();
+        Assert.AreEqual(1, Debugs.Count);
+        Assert.IsTrue(Debugs.First().StartsWith("Method: 'Void AsyncDelegateMethod()'. Line: ~"), Debugs.First());
     }
 
     [Test]

--- a/Log4NetFody/TypeProcessor.cs
+++ b/Log4NetFody/TypeProcessor.cs
@@ -61,11 +61,7 @@ public partial class ModuleWeaver
 		var staticConstructor = type.GetStaticConstructor();
 	    var instructions = staticConstructor.Body.Instructions;
 
-        var logName = type.FullName;
-        if (type.IsCompilerGenerated() && type.IsNested)
-        {
-            logName = type.DeclaringType.FullName;
-        }
+        var logName = type.GetNonCompilerGeneratedType().FullName;
 
         instructions.Insert(0, Instruction.Create(OpCodes.Ldstr, logName));
 	    instructions.Insert(1, Instruction.Create(OpCodes.Call, constructLoggerMethod));

--- a/MetroLogAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
+++ b/MetroLogAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
@@ -28,4 +28,10 @@ public class ClassWithCompilerGeneratedClasses
         Action<string> log = l => LogTo.Debug(l, x);
         log("Foo {0}");
     }
+
+    public void AsyncDelegateMethod()
+    {
+        var action = new Action(async () => LogTo.Debug());
+        action();
+    }
 }

--- a/MetroLogFody/MetroLogTests.cs
+++ b/MetroLogFody/MetroLogTests.cs
@@ -677,6 +677,16 @@ public class MetroLogTests
     }
 
     [Test]
+    public void AsyncDelegateMethod()
+    {
+        var type = assembly.GetType("ClassWithCompilerGeneratedClasses");
+        var instance = (dynamic)Activator.CreateInstance(type);
+        instance.AsyncDelegateMethod();
+        Assert.AreEqual(1, Debugs.Count);
+        Assert.IsTrue(Debugs.First().StartsWith("Method: 'Void AsyncDelegateMethod()'. Line: ~"), Debugs.First());
+    }
+
+    [Test]
     public void LambdaMethod()
     {
         var type = assembly.GetType("ClassWithCompilerGeneratedClasses");

--- a/MetroLogFody/TypeProcessor.cs
+++ b/MetroLogFody/TypeProcessor.cs
@@ -58,11 +58,7 @@ public partial class ModuleWeaver
 
     void InjectField(TypeDefinition type, FieldDefinition fieldDefinition)
 	{
-        var logName = type.FullName;
-        if (type.IsCompilerGenerated() && type.IsNested)
-        {
-            logName = type.DeclaringType.FullName;
-        }
+        var logName = type.GetNonCompilerGeneratedType().FullName;
 		var staticConstructor = type.GetStaticConstructor();
 	    var instructions = staticConstructor.Body.Instructions;
 	    instructions.Insert(0, Instruction.Create(OpCodes.Call, GetDefaultLogManager));

--- a/NLogAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
+++ b/NLogAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
@@ -28,4 +28,10 @@ public class ClassWithCompilerGeneratedClasses
         Action<string> log = l => LogTo.Debug(l, x);
         log("Foo {0}");
     }
+
+    public void AsyncDelegateMethod()
+    {
+        var action = new Action(async () => LogTo.Debug());
+        action();
+    }
 }

--- a/NLogFody/NLogTests.cs
+++ b/NLogFody/NLogTests.cs
@@ -684,6 +684,16 @@ public class NLogTests
     }
 
     [Test]
+    public void AsyncDelegateMethod()
+    {
+        var type = assembly.GetType("ClassWithCompilerGeneratedClasses");
+        var instance = (dynamic)Activator.CreateInstance(type);
+        instance.AsyncDelegateMethod();
+        Assert.AreEqual(1, Debugs.Count);
+        Assert.IsTrue(Debugs.First().StartsWith("Method: 'Void AsyncDelegateMethod()'. Line: ~"), Debugs.First());
+    }
+
+    [Test]
     public void LambdaMethod()
     {
         var type = assembly.GetType("ClassWithCompilerGeneratedClasses");

--- a/NLogFody/TypeProcessor.cs
+++ b/NLogFody/TypeProcessor.cs
@@ -69,11 +69,7 @@ public partial class ModuleWeaver
 	    }
 	    else
 	    {
-	        var logName = type.FullName;
-	        if (type.IsCompilerGenerated() && type.IsNested)
-	        {
-	            logName = type.DeclaringType.FullName;
-	        }
+	        var logName = type.GetNonCompilerGeneratedType().FullName;
 
 	        instructions.Insert(0, Instruction.Create(OpCodes.Ldstr, logName));
 	        instructions.Insert(1, Instruction.Create(OpCodes.Call, constructLoggerMethod));

--- a/NServiceBusAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
+++ b/NServiceBusAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
@@ -28,4 +28,10 @@ public class ClassWithCompilerGeneratedClasses
         Action<string> log = l => LogTo.Debug(l, x);
         log("Foo {0}");
     }
+
+    public void AsyncDelegateMethod()
+    {
+        var action = new Action(async () => LogTo.Debug());
+        action();
+    }
 }

--- a/NServiceBusFody/NServiceBusTests.cs
+++ b/NServiceBusFody/NServiceBusTests.cs
@@ -28,7 +28,7 @@ public class NServiceBusTests
 #endif
         afterAssemblyPath = WeaverHelper.Weave(beforeAssemblyPath);
         assembly = Assembly.LoadFile(afterAssemblyPath);
-       
+
         LogManager.UseFactory(new LogCapture(this));
     }
 
@@ -507,7 +507,7 @@ public class NServiceBusTests
         Assert.AreEqual(1, Fatals.Count);
         Assert.IsTrue(Fatals.First().StartsWith("Method: 'void FatalStringExceptionFunc()'. Line: ~"));
     }
-    
+
     [Test]
     public void PeVerify()
     {
@@ -543,6 +543,15 @@ public class NServiceBusTests
         instance.DelegateMethod();
         Assert.AreEqual(1, Debugs.Count);
         Assert.IsTrue(Debugs.First().StartsWith("Method: 'Void DelegateMethod()'. Line: ~"), Debugs.First());
+    }
+    [Test]
+    public void AsyncDelegateMethod()
+    {
+        var type = assembly.GetType("ClassWithCompilerGeneratedClasses");
+        var instance = (dynamic)Activator.CreateInstance(type);
+        instance.AsyncDelegateMethod();
+        Assert.AreEqual(1, Debugs.Count);
+        Assert.IsTrue(Debugs.First().StartsWith("Method: 'Void AsyncDelegateMethod()'. Line: ~"), Debugs.First());
     }
     [Test]
     public void LambdaMethod()

--- a/NServiceBusFody/TypeProcessor.cs
+++ b/NServiceBusFody/TypeProcessor.cs
@@ -62,11 +62,7 @@ public partial class ModuleWeaver
         var staticConstructor = type.GetStaticConstructor();
         var instructions = staticConstructor.Body.Instructions;
 
-        var logName = type.FullName;
-        if (type.IsCompilerGenerated() && type.IsNested)
-        {
-            logName = type.DeclaringType.FullName;
-        }
+        var logName = type.GetNonCompilerGeneratedType().FullName;
 
         instructions.Insert(0, Instruction.Create(OpCodes.Ldstr, logName));
         instructions.Insert(1, Instruction.Create(OpCodes.Call, constructLoggerMethod));

--- a/SerilogAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
+++ b/SerilogAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
@@ -30,4 +30,10 @@ public class ClassWithCompilerGeneratedClasses
         Action<string> log = l => LogTo.Debug(l, x);
         log("Foo {0}");
     }
+
+    public void AsyncDelegateMethod()
+    {
+        var action = new Action(async () => LogTo.Debug());
+        action();
+    }
 }

--- a/SerilogFody/LogEventExtensions.cs
+++ b/SerilogFody/LogEventExtensions.cs
@@ -14,4 +14,9 @@ public static class LogEventExtensions
         var logEventPropertyValue = (ScalarValue)logEvent.Properties["LineNumber"];
         return (int)logEventPropertyValue.Value;
     }
+    public static string SourceContext(this LogEvent logEvent)
+    {
+        var logEventPropertyValue = (ScalarValue)logEvent.Properties["SourceContext"];
+        return (string)logEventPropertyValue.Value;
+    }
 }

--- a/SerilogFody/SerilogTests.cs
+++ b/SerilogFody/SerilogTests.cs
@@ -59,9 +59,9 @@ public class SerilogTests
     public void Setup()
     {
         var eventSink = new EventSink
-            {
-                Action = LogEvent
-            };
+        {
+            Action = LogEvent
+        };
 
         Log.Logger = new LoggerConfiguration()
             .MinimumLevel.Verbose()
@@ -79,8 +79,8 @@ public class SerilogTests
     public void Generic()
     {
         var type = assembly.GetType("GenericClass`1");
-        var constructedType = type.MakeGenericType(typeof (string));
-        var instance = (dynamic) Activator.CreateInstance(constructedType);
+        var constructedType = type.MakeGenericType(typeof(string));
+        var instance = (dynamic)Activator.CreateInstance(constructedType);
         instance.Debug();
         var logEvent = debugs.Single();
         Assert.AreEqual(7, logEvent.LineNumber());
@@ -104,7 +104,7 @@ public class SerilogTests
         var type = assembly.GetType("ClassWithStaticConstructor");
         type.GetMethod("StaticMethod", BindingFlags.Static | BindingFlags.Public).Invoke(null, null);
         // ReSharper disable once PossibleNullReferenceException
-        var message = (string) type.GetField("Message", BindingFlags.Static | BindingFlags.Public).GetValue(null);
+        var message = (string)type.GetField("Message", BindingFlags.Static | BindingFlags.Public).GetValue(null);
         Assert.AreEqual("Foo", message);
     }
 
@@ -113,7 +113,7 @@ public class SerilogTests
     {
         var type = assembly.GetType("ClassWithExistingField");
         Assert.AreEqual(1, type.GetFields(BindingFlags.NonPublic | BindingFlags.Static).Count());
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         instance.Debug();
         Assert.AreEqual(1, debugs.Count);
         var logEvent = debugs.First();
@@ -127,7 +127,7 @@ public class SerilogTests
     {
         Exception exception = null;
         var type = assembly.GetType("OnException");
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         try
         {
             action(instance);
@@ -246,7 +246,7 @@ public class SerilogTests
     public void DebugString()
     {
         var type = assembly.GetType("ClassWithLogging");
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         instance.DebugString();
         var logEvent = debugs.Single();
         Assert.AreEqual(18, logEvent.LineNumber());
@@ -257,7 +257,7 @@ public class SerilogTests
     public void DebugStringParams()
     {
         var type = assembly.GetType("ClassWithLogging");
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         instance.DebugStringParams();
         var logEvent = debugs.Single();
         Assert.AreEqual(23, logEvent.LineNumber());
@@ -269,7 +269,7 @@ public class SerilogTests
     public void DebugStringException()
     {
         var type = assembly.GetType("ClassWithLogging");
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         instance.DebugStringException();
         var logEvent = debugs.Single();
         Assert.AreEqual(28, logEvent.LineNumber());
@@ -289,7 +289,7 @@ public class SerilogTests
     public void Information()
     {
         var type = assembly.GetType("ClassWithLogging");
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         instance.Information();
         var logEvent = informations.Single();
         Assert.AreEqual(38, logEvent.LineNumber());
@@ -301,7 +301,7 @@ public class SerilogTests
     public void InformationString()
     {
         var type = assembly.GetType("ClassWithLogging");
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         instance.InformationString();
         var logEvent = informations.Single();
         Assert.AreEqual(43, logEvent.LineNumber());
@@ -313,7 +313,7 @@ public class SerilogTests
     public void InformationStringParams()
     {
         var type = assembly.GetType("ClassWithLogging");
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         instance.InformationStringParams();
         var logEvent = informations.Single();
         Assert.AreEqual(48, logEvent.LineNumber());
@@ -326,7 +326,7 @@ public class SerilogTests
     public void InformationStringException()
     {
         var type = assembly.GetType("ClassWithLogging");
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         instance.InformationStringException();
         var logEvent = informations.Single();
         Assert.AreEqual(53, logEvent.LineNumber());
@@ -346,7 +346,7 @@ public class SerilogTests
     public void Warning()
     {
         var type = assembly.GetType("ClassWithLogging");
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         instance.Warning();
         var logEvent = warns.Single();
         Assert.AreEqual(63, logEvent.LineNumber());
@@ -358,7 +358,7 @@ public class SerilogTests
     public void WarningString()
     {
         var type = assembly.GetType("ClassWithLogging");
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         instance.WarningString();
         var logEvent = warns.Single();
         Assert.AreEqual(68, logEvent.LineNumber());
@@ -370,7 +370,7 @@ public class SerilogTests
     public void WarningStringParams()
     {
         var type = assembly.GetType("ClassWithLogging");
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         instance.WarningStringParams();
         var logEvent = warns.Single();
         Assert.AreEqual(73, logEvent.LineNumber());
@@ -382,7 +382,7 @@ public class SerilogTests
     public void WarningStringException()
     {
         var type = assembly.GetType("ClassWithLogging");
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         instance.WarningStringException();
         var logEvent = warns.Single();
         Assert.AreEqual(78, logEvent.LineNumber());
@@ -401,7 +401,7 @@ public class SerilogTests
     public void Error()
     {
         var type = assembly.GetType("ClassWithLogging");
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         instance.Error();
         var logEvent = errors.Single();
         Assert.AreEqual(88, logEvent.LineNumber());
@@ -413,7 +413,7 @@ public class SerilogTests
     public void ErrorString()
     {
         var type = assembly.GetType("ClassWithLogging");
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         instance.ErrorString();
         var logEvent = errors.Single();
         Assert.AreEqual(93, logEvent.LineNumber());
@@ -425,7 +425,7 @@ public class SerilogTests
     public void ErrorStringParams()
     {
         var type = assembly.GetType("ClassWithLogging");
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         instance.ErrorStringParams();
         var logEvent = errors.Single();
         Assert.AreEqual(98, logEvent.LineNumber());
@@ -437,7 +437,7 @@ public class SerilogTests
     public void ErrorStringException()
     {
         var type = assembly.GetType("ClassWithLogging");
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         instance.ErrorStringException();
         var logEvent = errors.Single();
         Assert.AreEqual(103, logEvent.LineNumber());
@@ -456,7 +456,7 @@ public class SerilogTests
     public void Fatal()
     {
         var type = assembly.GetType("ClassWithLogging");
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         instance.Fatal();
         var logEvent = fatals.Single();
         Assert.AreEqual(113, logEvent.LineNumber());
@@ -469,7 +469,7 @@ public class SerilogTests
     public void FatalString()
     {
         var type = assembly.GetType("ClassWithLogging");
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         instance.FatalString();
         var logEvent = fatals.Single();
         Assert.AreEqual(118, logEvent.LineNumber());
@@ -481,7 +481,7 @@ public class SerilogTests
     public void FatalStringParams()
     {
         var type = assembly.GetType("ClassWithLogging");
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         instance.FatalStringParams();
         var logEvent = fatals.Single();
         Assert.AreEqual(123, logEvent.LineNumber());
@@ -493,7 +493,7 @@ public class SerilogTests
     public void FatalStringException()
     {
         var type = assembly.GetType("ClassWithLogging");
-        var instance = (dynamic) Activator.CreateInstance(type);
+        var instance = (dynamic)Activator.CreateInstance(type);
         instance.FatalStringException();
         var logEvent = fatals.Single();
         Assert.AreEqual(128, logEvent.LineNumber());
@@ -506,7 +506,7 @@ public class SerilogTests
     {
         Verifier.Verify(beforeAssemblyPath, afterAssemblyPath);
     }
-    
+
     [Test]
     public void AsyncMethod()
     {
@@ -540,6 +540,18 @@ public class SerilogTests
         var logEvent = debugs.Single();
         Assert.AreEqual(23, logEvent.LineNumber());
         Assert.AreEqual("Void DelegateMethod()", logEvent.MethodName());
+        Assert.AreEqual("", logEvent.MessageTemplate.Text);
+    }
+
+    [Test]
+    public void AsyncDelegateMethod()
+    {
+        var type = assembly.GetType("ClassWithCompilerGeneratedClasses");
+        var instance = (dynamic)Activator.CreateInstance(type);
+        instance.AsyncDelegateMethod();
+        var logEvent = debugs.Single();
+        Assert.AreEqual(36, logEvent.LineNumber());
+        Assert.AreEqual("Void AsyncDelegateMethod()", logEvent.MethodName());
         Assert.AreEqual("", logEvent.MessageTemplate.Text);
     }
 

--- a/SerilogFody/SerilogTests.cs
+++ b/SerilogFody/SerilogTests.cs
@@ -52,7 +52,6 @@ public class SerilogTests
         {
             warns.Add(eventInfo);
         }
-
     }
 
     [SetUp]
@@ -86,8 +85,8 @@ public class SerilogTests
         Assert.AreEqual(7, logEvent.LineNumber());
         Assert.AreEqual("Void Debug()", logEvent.MethodName());
         Assert.AreEqual("", logEvent.MessageTemplate.Text);
+        Assert.IsTrue(logEvent.SourceContext().StartsWith("GenericClass`1"), logEvent.SourceContext());
     }
-
 
     [Test]
     public void MethodThatReturns()
@@ -120,6 +119,7 @@ public class SerilogTests
         Assert.AreEqual(17, logEvent.LineNumber());
         Assert.AreEqual("Void Debug()", logEvent.MethodName());
         Assert.AreEqual("", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithExistingField", logEvent.SourceContext());
     }
 
     // ReSharper disable once UnusedParameter.Local
@@ -141,7 +141,6 @@ public class SerilogTests
         var first = list.First();
         Assert.IsTrue(first.MessageTemplate.Text.StartsWith(expected), first.MessageTemplate.Text);
     }
-
 
     [Test]
     public void OnExceptionToDebug()
@@ -223,7 +222,6 @@ public class SerilogTests
         CheckException(action, fatals, expected);
     }
 
-
     [Test]
     public void IsDebugEnabled()
     {
@@ -231,6 +229,7 @@ public class SerilogTests
         var instance = (dynamic)Activator.CreateInstance(type);
         Assert.IsTrue(instance.IsDebugEnabled());
     }
+
     [Test]
     public void Debug()
     {
@@ -241,7 +240,9 @@ public class SerilogTests
         Assert.AreEqual(13, logEvent.LineNumber());
         Assert.AreEqual("Void Debug()", logEvent.MethodName());
         Assert.AreEqual("", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithLogging", logEvent.SourceContext());
     }
+
     [Test]
     public void DebugString()
     {
@@ -252,7 +253,9 @@ public class SerilogTests
         Assert.AreEqual(18, logEvent.LineNumber());
         Assert.AreEqual("Void DebugString()", logEvent.MethodName());
         Assert.AreEqual("TheMessage", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithLogging", logEvent.SourceContext());
     }
+
     [Test]
     public void DebugStringParams()
     {
@@ -263,6 +266,7 @@ public class SerilogTests
         Assert.AreEqual(23, logEvent.LineNumber());
         Assert.AreEqual("Void DebugStringParams()", logEvent.MethodName());
         Assert.AreEqual("TheMessage {0}", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithLogging", logEvent.SourceContext());
     }
 
     [Test]
@@ -275,8 +279,8 @@ public class SerilogTests
         Assert.AreEqual(28, logEvent.LineNumber());
         Assert.AreEqual("Void DebugStringException()", logEvent.MethodName());
         Assert.AreEqual("TheMessage", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithLogging", logEvent.SourceContext());
     }
-
 
     [Test]
     public void IsInformationEnabled()
@@ -285,6 +289,7 @@ public class SerilogTests
         var instance = (dynamic)Activator.CreateInstance(type);
         Assert.IsTrue(instance.IsInformationEnabled());
     }
+
     [Test]
     public void Information()
     {
@@ -295,6 +300,7 @@ public class SerilogTests
         Assert.AreEqual(38, logEvent.LineNumber());
         Assert.AreEqual("Void Information()", logEvent.MethodName());
         Assert.AreEqual("", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithLogging", logEvent.SourceContext());
     }
 
     [Test]
@@ -307,6 +313,7 @@ public class SerilogTests
         Assert.AreEqual(43, logEvent.LineNumber());
         Assert.AreEqual("Void InformationString()", logEvent.MethodName());
         Assert.AreEqual("TheMessage", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithLogging", logEvent.SourceContext());
     }
 
     [Test]
@@ -319,7 +326,7 @@ public class SerilogTests
         Assert.AreEqual(48, logEvent.LineNumber());
         Assert.AreEqual("Void InformationStringParams()", logEvent.MethodName());
         Assert.AreEqual("TheMessage {0}", logEvent.MessageTemplate.Text);
-
+        Assert.AreEqual("ClassWithLogging", logEvent.SourceContext());
     }
 
     [Test]
@@ -332,8 +339,9 @@ public class SerilogTests
         Assert.AreEqual(53, logEvent.LineNumber());
         Assert.AreEqual("Void InformationStringException()", logEvent.MethodName());
         Assert.AreEqual("TheMessage", logEvent.MessageTemplate.Text);
-
+        Assert.AreEqual("ClassWithLogging", logEvent.SourceContext());
     }
+
     [Test]
     public void IsWarningEnabled()
     {
@@ -352,6 +360,7 @@ public class SerilogTests
         Assert.AreEqual(63, logEvent.LineNumber());
         Assert.AreEqual("Void Warning()", logEvent.MethodName());
         Assert.AreEqual("", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithLogging", logEvent.SourceContext());
     }
 
     [Test]
@@ -364,6 +373,7 @@ public class SerilogTests
         Assert.AreEqual(68, logEvent.LineNumber());
         Assert.AreEqual("Void WarningString()", logEvent.MethodName());
         Assert.AreEqual("TheMessage", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithLogging", logEvent.SourceContext());
     }
 
     [Test]
@@ -376,6 +386,7 @@ public class SerilogTests
         Assert.AreEqual(73, logEvent.LineNumber());
         Assert.AreEqual("Void WarningStringParams()", logEvent.MethodName());
         Assert.AreEqual("TheMessage {0}", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithLogging", logEvent.SourceContext());
     }
 
     [Test]
@@ -388,7 +399,9 @@ public class SerilogTests
         Assert.AreEqual(78, logEvent.LineNumber());
         Assert.AreEqual("Void WarningStringException()", logEvent.MethodName());
         Assert.AreEqual("TheMessage", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithLogging", logEvent.SourceContext());
     }
+
     [Test]
     public void IsErrorEnabled()
     {
@@ -407,6 +420,7 @@ public class SerilogTests
         Assert.AreEqual(88, logEvent.LineNumber());
         Assert.AreEqual("Void Error()", logEvent.MethodName());
         Assert.AreEqual("", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithLogging", logEvent.SourceContext());
     }
 
     [Test]
@@ -419,6 +433,7 @@ public class SerilogTests
         Assert.AreEqual(93, logEvent.LineNumber());
         Assert.AreEqual("Void ErrorString()", logEvent.MethodName());
         Assert.AreEqual("TheMessage", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithLogging", logEvent.SourceContext());
     }
 
     [Test]
@@ -431,6 +446,7 @@ public class SerilogTests
         Assert.AreEqual(98, logEvent.LineNumber());
         Assert.AreEqual("Void ErrorStringParams()", logEvent.MethodName());
         Assert.AreEqual("TheMessage {0}", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithLogging", logEvent.SourceContext());
     }
 
     [Test]
@@ -443,7 +459,9 @@ public class SerilogTests
         Assert.AreEqual(103, logEvent.LineNumber());
         Assert.AreEqual("Void ErrorStringException()", logEvent.MethodName());
         Assert.AreEqual("TheMessage", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithLogging", logEvent.SourceContext());
     }
+
     [Test]
     public void IsFatalEnabled()
     {
@@ -462,7 +480,7 @@ public class SerilogTests
         Assert.AreEqual(113, logEvent.LineNumber());
         Assert.AreEqual("Void Fatal()", logEvent.MethodName());
         Assert.AreEqual("", logEvent.MessageTemplate.Text);
-
+        Assert.AreEqual("ClassWithLogging", logEvent.SourceContext());
     }
 
     [Test]
@@ -475,6 +493,7 @@ public class SerilogTests
         Assert.AreEqual(118, logEvent.LineNumber());
         Assert.AreEqual("Void FatalString()", logEvent.MethodName());
         Assert.AreEqual("TheMessage", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithLogging", logEvent.SourceContext());
     }
 
     [Test]
@@ -487,6 +506,7 @@ public class SerilogTests
         Assert.AreEqual(123, logEvent.LineNumber());
         Assert.AreEqual("Void FatalStringParams()", logEvent.MethodName());
         Assert.AreEqual("TheMessage {0}", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithLogging", logEvent.SourceContext());
     }
 
     [Test]
@@ -499,6 +519,7 @@ public class SerilogTests
         Assert.AreEqual(128, logEvent.LineNumber());
         Assert.AreEqual("Void FatalStringException()", logEvent.MethodName());
         Assert.AreEqual("TheMessage", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithLogging", logEvent.SourceContext());
     }
 
     [Test]
@@ -517,6 +538,7 @@ public class SerilogTests
         Assert.AreEqual(10, logEvent.LineNumber());
         Assert.AreEqual("Void AsyncMethod()", logEvent.MethodName());
         Assert.AreEqual("", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithCompilerGeneratedClasses", logEvent.SourceContext());
     }
 
     [Test]
@@ -529,6 +551,7 @@ public class SerilogTests
         Assert.AreEqual(16, logEvent.LineNumber());
         Assert.AreEqual("IEnumerable<Int32> EnumeratorMethod()", logEvent.MethodName());
         Assert.AreEqual("", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithCompilerGeneratedClasses", logEvent.SourceContext());
     }
 
     [Test]
@@ -541,6 +564,7 @@ public class SerilogTests
         Assert.AreEqual(23, logEvent.LineNumber());
         Assert.AreEqual("Void DelegateMethod()", logEvent.MethodName());
         Assert.AreEqual("", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithCompilerGeneratedClasses", logEvent.SourceContext());
     }
 
     [Test]
@@ -553,6 +577,7 @@ public class SerilogTests
         Assert.AreEqual(36, logEvent.LineNumber());
         Assert.AreEqual("Void AsyncDelegateMethod()", logEvent.MethodName());
         Assert.AreEqual("", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithCompilerGeneratedClasses", logEvent.SourceContext());
     }
 
     [Test]
@@ -565,6 +590,7 @@ public class SerilogTests
         Assert.AreEqual(30, logEvent.LineNumber());
         Assert.AreEqual("Void LambdaMethod()", logEvent.MethodName());
         Assert.AreEqual("Foo {0}", logEvent.MessageTemplate.Text);
+        Assert.AreEqual("ClassWithCompilerGeneratedClasses", logEvent.SourceContext());
     }
 
     [Test]

--- a/SerilogFody/TypeProcessor.cs
+++ b/SerilogFody/TypeProcessor.cs
@@ -13,9 +13,9 @@ public partial class ModuleWeaver
         if (fieldDefinition == null)
         {
             fieldDefinition = new FieldDefinition("AnotarLogger", FieldAttributes.Static | FieldAttributes.Private, loggerType)
-                              {
-                                  DeclaringType = type
-                              };
+            {
+                DeclaringType = type
+            };
             foundAction = () => InjectField(type, fieldDefinition);
         }
         else
@@ -33,21 +33,21 @@ public partial class ModuleWeaver
             }
 
             var onExceptionProcessor = new OnExceptionProcessor
-                                       {
-                                           Method = method,
-                                           LoggerField = fieldReference,
-                                           FoundUsageInType = () => foundUsage = true,
-                                           ModuleWeaver = this
-                                       };
+            {
+                Method = method,
+                LoggerField = fieldReference,
+                FoundUsageInType = () => foundUsage = true,
+                ModuleWeaver = this
+            };
             onExceptionProcessor.Process();
 
             var logForwardingProcessor = new LogForwardingProcessor
-                                         {
-                                             FoundUsageInType = () => foundUsage = true,
-                                             Method = method,
-                                             ModuleWeaver = this,
-                                             LoggerField = fieldReference,
-                                         };
+            {
+                FoundUsageInType = () => foundUsage = true,
+                Method = method,
+                ModuleWeaver = this,
+                LoggerField = fieldReference,
+            };
             logForwardingProcessor.ProcessMethod();
 
         }
@@ -63,14 +63,7 @@ public partial class ModuleWeaver
         var staticConstructor = type.GetStaticConstructor();
         staticConstructor.Body.SimplifyMacros();
         var genericInstanceMethod = new GenericInstanceMethod(forContextDefinition);
-        if (type.IsCompilerGenerated() && type.IsNested)
-        {
-            genericInstanceMethod.GenericArguments.Add(type.DeclaringType.GetGeneric());
-        }
-        else
-        {
-            genericInstanceMethod.GenericArguments.Add(type.GetGeneric());
-        }
+        genericInstanceMethod.GenericArguments.Add(type.GetNonCompilerGeneratedType().GetGeneric());
         var instructions = staticConstructor.Body.Instructions;
         type.Fields.Add(fieldDefinition);
 

--- a/SplatAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
+++ b/SplatAssemblyToProcess/ClassWithCompilerGeneratedClasses.cs
@@ -28,4 +28,10 @@ public class ClassWithCompilerGeneratedClasses
         Action<string> log = l => LogTo.Debug(l, x);
         log("Foo {0}");
     }
+
+    public void AsyncDelegateMethod()
+    {
+        var action = new Action(async () => LogTo.Debug());
+        action();
+    }
 }

--- a/SplatFody/SplatTests.cs
+++ b/SplatFody/SplatTests.cs
@@ -556,6 +556,16 @@ public class SplatTests
     }
 
     [Test]
+    public void AsyncDelegateMethod()
+    {
+        var type = assembly.GetType("ClassWithCompilerGeneratedClasses");
+        var instance = (dynamic)Activator.CreateInstance(type);
+        instance.AsyncDelegateMethod();
+        Assert.AreEqual(1, currentLogger.Debugs.Count);
+        Assert.IsTrue(currentLogger.Debugs.First().Contains("Method: 'Void AsyncDelegateMethod()'. Line: ~"), currentLogger.Debugs.First());
+    }
+
+    [Test]
     public void LambdaMethod()
     {
         var type = assembly.GetType("ClassWithCompilerGeneratedClasses");

--- a/SplatFody/TypeProcessor.cs
+++ b/SplatFody/TypeProcessor.cs
@@ -62,11 +62,7 @@ public partial class ModuleWeaver
         var staticConstructor = type.GetStaticConstructor();
         var instructions = staticConstructor.Body.Instructions;
 
-        var targetType = type;
-        if (type.IsCompilerGenerated() && type.IsNested)
-        {
-            targetType = type.DeclaringType;
-        }
+        var targetType = type.GetNonCompilerGeneratedType();
         var logManagerVariable = new VariableDefinition(LogManagerType);
         staticConstructor.Body.Variables.Add(logManagerVariable);
 


### PR DESCRIPTION
Fixes issue #59.

With async delegates, the following problems have been fixed.

- The type used in the logger is a compiler generated class, not the original class.
- The method was not detected properly, so the method was recorded as "MoveNext".