### PR TITLE
Fix for infinite loop when log level disabled (log4net).

### DIFF
--- a/Log4NetFody/Log4NetTests.cs
+++ b/Log4NetFody/Log4NetTests.cs
@@ -631,4 +631,24 @@ public class Log4NetTests
 
         Assert.NotNull(instance.DoIt());
     }
+
+    [Test, Timeout(1000)]
+    public void Issue73()
+    {
+        var hierarchy = LogManager.GetRepository();
+        var previousThreshold = hierarchy.Threshold;
+        hierarchy.Threshold = Level.Info;
+
+        try
+        {
+            var type = assembly.GetType("ClassWithLogging");
+            var instance = (dynamic) Activator.CreateInstance(type);
+            instance.DebugStringFunc();
+            Assert.AreEqual(0, Debugs.Count);
+        }
+        finally
+        {
+            hierarchy.Threshold = previousThreshold;
+        }
+    }
 }

--- a/Log4NetFody/LogForwardingProcessor.cs
+++ b/Log4NetFody/LogForwardingProcessor.cs
@@ -218,6 +218,7 @@ public class LogForwardingProcessor
                     Instruction.Create(OpCodes.Call, ModuleWeaver.ConcatMethod),
                     Instruction.Create(OpCodes.Ldnull),
                     Instruction.Create(OpCodes.Callvirt, ModuleWeaver.GetFormatOperand(methodReference)),
+                    sectionNop
                 });
             return;
         }


### PR DESCRIPTION
The weaver for the LogTo.*(Func&lt;string&gt; message) overloads are generating infinite loops when a logging level is disabled.

For example, calling `LogTo.Debug(() => "My Message");`, the generated code is something like this:

```c#
Func<string> func;
do
{
  func = () => "My message";
} while (!AnotarLogger.IsDebugEnabled);
AnotarLogger.DebugFormat("" + func(), null);
```

This obviously causes a problem when the log level is set higher than DEBUG.

This pull request changes the generated code to:

```c#
Func<string> func = () => "My message";
if (AnotarLogger.IsDebugEnabled)
{
  AnotarLogger.DebugFormat("" + func(), null);
}
```