### PR TITLE
Fixes #76. Adds version numbers to assemblies referenced in .csproj

### DIFF
--- a/CatelReferenceAssembly/CatelReferenceAssembly.csproj
+++ b/CatelReferenceAssembly/CatelReferenceAssembly.csproj
@@ -49,6 +49,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="LogToErrorOnExceptionAttribute.cs" />
     <Compile Include="LogTo.cs" />
     <Compile Include="LogMinimalMessageAttribute.cs" />

--- a/CommonLoggingReferenceAssembly/CommonLoggingReferenceAssembly.csproj
+++ b/CommonLoggingReferenceAssembly/CommonLoggingReferenceAssembly.csproj
@@ -46,6 +46,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="LogMinimalMessageAttribute.cs" />
     <Compile Include="LogTo.cs" />
     <Compile Include="LogToDebugOnExceptionAttribute.cs" />

--- a/CustomReferenceAssembly_Portable/CustomReferenceAssembly_Portable.csproj
+++ b/CustomReferenceAssembly_Portable/CustomReferenceAssembly_Portable.csproj
@@ -50,6 +50,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="LogTo.cs" />
     <Compile Include="LoggerFactoryAttribute.cs" />
     <Compile Include="LogToFatalOnExceptionAttribute.cs" />

--- a/LibLogReferenceAssembly/LibLogReferenceAssembly.csproj
+++ b/LibLogReferenceAssembly/LibLogReferenceAssembly.csproj
@@ -52,6 +52,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="LogTo.cs" />
     <Compile Include="LogToFatalOnExceptionAttribute.cs" />
     <Compile Include="LogMinimalMessageAttribute.cs" />

--- a/Log4NetReferenceAssembly/Log4NetReferenceAssembly.csproj
+++ b/Log4NetReferenceAssembly/Log4NetReferenceAssembly.csproj
@@ -50,6 +50,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="LogTo.cs" />
     <Compile Include="LogToFatalOnExceptionAttribute.cs" />
     <Compile Include="LogMinimalMessageAttribute.cs" />

--- a/MetroLogReferenceAssembly/MetroLogReferenceAssembly.csproj
+++ b/MetroLogReferenceAssembly/MetroLogReferenceAssembly.csproj
@@ -51,6 +51,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="LogTo.cs" />
     <Compile Include="LogToFatalOnExceptionAttribute.cs" />
     <Compile Include="LogMinimalMessageAttribute.cs" />

--- a/NLogReferenceAssembly/NLogReferenceAssembly.csproj
+++ b/NLogReferenceAssembly/NLogReferenceAssembly.csproj
@@ -52,6 +52,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="LogTo.cs" />
     <Compile Include="LogToFatalOnExceptionAttribute.cs" />
     <Compile Include="LogMinimalMessageAttribute.cs" />

--- a/NServiceBusReferenceAssembly/NServiceBusReferenceAssembly.csproj
+++ b/NServiceBusReferenceAssembly/NServiceBusReferenceAssembly.csproj
@@ -52,6 +52,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="LogTo.cs" />
     <Compile Include="LogToFatalOnExceptionAttribute.cs" />
     <Compile Include="LogMinimalMessageAttribute.cs" />

--- a/SerilogReferenceAssembly/SerilogReferenceAssembly.csproj
+++ b/SerilogReferenceAssembly/SerilogReferenceAssembly.csproj
@@ -51,6 +51,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="LogTo.cs" />
     <Compile Include="LogToFatalOnExceptionAttribute.cs" />
     <Compile Include="LogToDebugOnExceptionAttribute.cs" />

--- a/SplatReferenceAssembly/SplatReferenceAssembly.csproj
+++ b/SplatReferenceAssembly/SplatReferenceAssembly.csproj
@@ -50,6 +50,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\CommonAssemblyInfo.cs">
+      <Link>CommonAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="LogTo.cs" />
     <Compile Include="LogToFatalOnExceptionAttribute.cs" />
     <Compile Include="LogMinimalMessageAttribute.cs" />


### PR DESCRIPTION
This will prevent .csproj files from having <Reference /> to files with a version of 0.0.0.0. If these versions were left at 0.0.0.0 intentionally then of course reject this pull request.