### PR TITLE
Integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ Thumbs.db
 # Folder config file
 Desktop.ini
 
+/Tools

--- a/Anotar.IntegrationTests.sln
+++ b/Anotar.IntegrationTests.sln
@@ -1,0 +1,71 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.7
+MinimumVisualStudioVersion = 14.0.22823.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Custom", "Custom", "{FBFC972E-D7DD-4E72-A8C0-118A33A5913D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CustomReferenceAssembly", "CustomReferenceAssembly\CustomReferenceAssembly.csproj", "{E3DE8267-DA21-48DC-88F8-61A907CD91EA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CustomAssemblyWithLogger", "CustomAssemblyWithLogger\CustomAssemblyWithLogger.csproj", "{B7C06B67-01DE-4B4E-B568-42D12A15820E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntegrationTests", "IntegrationTests\IntegrationTests.csproj", "{D46E44D3-1D39-4816-B334-383034FA6CDF}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|Mixed Platforms = Debug|Mixed Platforms
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|Mixed Platforms = Release|Mixed Platforms
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E3DE8267-DA21-48DC-88F8-61A907CD91EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E3DE8267-DA21-48DC-88F8-61A907CD91EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E3DE8267-DA21-48DC-88F8-61A907CD91EA}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{E3DE8267-DA21-48DC-88F8-61A907CD91EA}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{E3DE8267-DA21-48DC-88F8-61A907CD91EA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E3DE8267-DA21-48DC-88F8-61A907CD91EA}.Debug|x86.Build.0 = Debug|Any CPU
+		{E3DE8267-DA21-48DC-88F8-61A907CD91EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E3DE8267-DA21-48DC-88F8-61A907CD91EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E3DE8267-DA21-48DC-88F8-61A907CD91EA}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{E3DE8267-DA21-48DC-88F8-61A907CD91EA}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{E3DE8267-DA21-48DC-88F8-61A907CD91EA}.Release|x86.ActiveCfg = Release|Any CPU
+		{E3DE8267-DA21-48DC-88F8-61A907CD91EA}.Release|x86.Build.0 = Release|Any CPU
+		{B7C06B67-01DE-4B4E-B568-42D12A15820E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7C06B67-01DE-4B4E-B568-42D12A15820E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7C06B67-01DE-4B4E-B568-42D12A15820E}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{B7C06B67-01DE-4B4E-B568-42D12A15820E}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{B7C06B67-01DE-4B4E-B568-42D12A15820E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B7C06B67-01DE-4B4E-B568-42D12A15820E}.Debug|x86.Build.0 = Debug|Any CPU
+		{B7C06B67-01DE-4B4E-B568-42D12A15820E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7C06B67-01DE-4B4E-B568-42D12A15820E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7C06B67-01DE-4B4E-B568-42D12A15820E}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B7C06B67-01DE-4B4E-B568-42D12A15820E}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{B7C06B67-01DE-4B4E-B568-42D12A15820E}.Release|x86.ActiveCfg = Release|Any CPU
+		{B7C06B67-01DE-4B4E-B568-42D12A15820E}.Release|x86.Build.0 = Release|Any CPU
+		{D46E44D3-1D39-4816-B334-383034FA6CDF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D46E44D3-1D39-4816-B334-383034FA6CDF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D46E44D3-1D39-4816-B334-383034FA6CDF}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{D46E44D3-1D39-4816-B334-383034FA6CDF}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{D46E44D3-1D39-4816-B334-383034FA6CDF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D46E44D3-1D39-4816-B334-383034FA6CDF}.Debug|x86.Build.0 = Debug|Any CPU
+		{D46E44D3-1D39-4816-B334-383034FA6CDF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D46E44D3-1D39-4816-B334-383034FA6CDF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D46E44D3-1D39-4816-B334-383034FA6CDF}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{D46E44D3-1D39-4816-B334-383034FA6CDF}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{D46E44D3-1D39-4816-B334-383034FA6CDF}.Release|x86.ActiveCfg = Release|Any CPU
+		{D46E44D3-1D39-4816-B334-383034FA6CDF}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{E3DE8267-DA21-48DC-88F8-61A907CD91EA} = {FBFC972E-D7DD-4E72-A8C0-118A33A5913D}
+		{B7C06B67-01DE-4B4E-B568-42D12A15820E} = {FBFC972E-D7DD-4E72-A8C0-118A33A5913D}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		EnterpriseLibraryConfigurationToolBinariesPath = packages\Unity.2.1.505.2\lib\NET35;packages\Unity.Interception.2.1.505.2\lib\NET35;packages\EnterpriseLibrary.Common.5.0.505.0\lib\NET35;packages\EnterpriseLibrary.Logging.5.0.505.1\lib\NET35
+	EndGlobalSection
+EndGlobal

--- a/Anotar.IntegrationTests.sln
+++ b/Anotar.IntegrationTests.sln
@@ -11,6 +11,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CustomAssemblyWithLogger", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntegrationTests", "IntegrationTests\IntegrationTests.csproj", "{D46E44D3-1D39-4816-B334-383034FA6CDF}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{06B30E20-E41D-4D75-8C7B-1C653774852F}"
+	ProjectSection(SolutionItems) = preProject
+		appveyor.yml = appveyor.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/CustomFody/CustomFody.csproj
+++ b/CustomFody/CustomFody.csproj
@@ -45,7 +45,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <Target Name="PreparePackage" AfterTargets="Build" Condition="$(Configuration) == 'Release'">
+  <Target Name="PreparePackage" AfterTargets="Build">
     <ItemGroup>
       <FilesToDelete Include="..\NuGetBuild\Custom\**\*.*" />
       <ReferenceAssemblyBinaries Include="..\CustomReferenceAssembly\bin\$(Configuration)\**\*.dll" />
@@ -56,6 +56,7 @@
     <Copy SourceFiles="@(ReferenceAssemblyXmlDocs)" DestinationFolder="..\NuGetBuild\Custom\Lib\%(RecursiveDir)" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\Anotar.Custom.Fody.nuspec" DestinationFolder="..\NuGetBuild\Custom" />
     <Copy SourceFiles="$(OutputPath)Anotar.Custom.Fody.dll" DestinationFolder="..\NuGetBuild\Custom" />
+    <Copy SourceFiles="$(OutputPath)Anotar.Custom.Fody.dll" DestinationFolder="..\Tools" />
     <Copy SourceFiles="$(OutputPath)Anotar.Custom.Fody.pdb" DestinationFolder="..\NuGetBuild\Custom" />
   </Target>
 </Project>

--- a/IntegrationTests/AnotarCustom.cs
+++ b/IntegrationTests/AnotarCustom.cs
@@ -1,0 +1,14 @@
+﻿[assembly: Anotar.Custom.LoggerFactory(typeof(LoggerFactory))]
+
+namespace IntegrationTests
+{
+    public class AnotarCustom
+    {
+        public void Weave()
+        {
+            Anotar.Custom.LogTo.Debug("This weaver should work: {0}", "Custom");
+        }
+    }
+}
+
+

--- a/IntegrationTests/FodyWeavers.xml
+++ b/IntegrationTests/FodyWeavers.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Weavers>
+  <Anotar.Custom />
+</Weavers>

--- a/IntegrationTests/IntegrationTests.csproj
+++ b/IntegrationTests/IntegrationTests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp1.1;net35;net462;netstandard1.0;portable-net4+sl50+win8+wpa81+wp8</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Fody" Version="2.0.10" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CustomAssemblyWithLogger\CustomAssemblyWithLogger.csproj" />
+    <ProjectReference Include="..\CustomReferenceAssembly\CustomReferenceAssembly.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'portable-net4+sl50+win8+wpa81+wp8' ">
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net35'">
+    <FrameworkPathOverride>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
+  </PropertyGroup>
+
+</Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ install:
 before_build:
   - nuget restore Anotar.sln
   - dotnet restore Anotar.NetStandard.sln
+  - dotnet restore Anotar.IntegrationTests.sln
   - ps: gitversion /l console /output buildserver /updateassemblyinfo
 
 configuration: Release
@@ -32,6 +33,7 @@ after_test:
          if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  };
          Pop-Location 
       }
+  - dotnet build Anotar.IntegrationTests.sln
 
 artifacts:
   - path: 'NuGetBuild\*.nupkg'


### PR DESCRIPTION
This adds a project which uses actual Fody nuget package and `FodyWeavers.xml` as it apparently behaved differently from the in-proc weaving used in unit tests.

Unfortunately it currently fails to build with dotnet CLI. See Fody/Fody#330 and dotnet/cli#5457