### PR TITLE
Configure logging

### DIFF
--- a/Catel/Anotar.Catel.Fody/LogForwardingProcessor.cs
+++ b/Catel/Anotar.Catel.Fody/LogForwardingProcessor.cs
@@ -246,6 +246,7 @@ public class LogForwardingProcessor
             return string.Empty;
         }
 
+        var sb = new StringBuilder();
 
         string methodName = null;
 

--- a/Catel/Anotar.Catel.Fody/LogForwardingProcessor.cs
+++ b/Catel/Anotar.Catel.Fody/LogForwardingProcessor.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Rocks;
 using Mono.Cecil.Cil;
+using System.Text;
 
 public class LogForwardingProcessor
 {
@@ -245,10 +246,31 @@ public class LogForwardingProcessor
             return string.Empty;
         }
 
-        if (instruction.TryGetPreviousLineNumber(Method, out var lineNumber))
+
+        string methodName = null;
+
+        if (!ModuleWeaver.DoNotLogMethodName)
         {
-            return $"Method: '{Method.DisplayName()}'. Line: ~{lineNumber}. ";
+            if (ModuleWeaver.LogMinimalMethodName)
+            {
+                methodName = Method.MinimalDisplayName();
+            }
+            else
+            {
+                methodName = Method.DisplayName();
+            }
         }
-        return $"Method: '{Method.DisplayName()}'. ";
+
+        if (methodName != null)
+        {
+            sb.Append("Method: '").Append(methodName).Append("'. ");
+        }
+
+        if (!ModuleWeaver.DoNotLogLineNumber && instruction.TryGetPreviousLineNumber(Method, out var lineNumber))
+        {
+            sb.Append("Line: ~").Append(lineNumber).Append(". ");
+        }
+
+        return sb.ToString();
     }
 }

--- a/Catel/Anotar.Catel.Fody/ModuleWeaver.cs
+++ b/Catel/Anotar.Catel.Fody/ModuleWeaver.cs
@@ -2,18 +2,41 @@
 using System.Linq;
 using Fody;
 
-public partial class ModuleWeaver:BaseModuleWeaver
+public partial class ModuleWeaver : BaseModuleWeaver
 {
     public bool LogMinimalMessage;
+    public bool LogMinimalMethodName;
+    public bool DoNotLogMethodName;
+    public bool DoNotLogLineNumber;
 
     public override void Execute()
     {
-        var assemblyContainsAttribute = ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.Catel.LogMinimalMessageAttribute");
-        var moduleContainsAttribute = ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.Catel.LogMinimalMessageAttribute");
-        if (assemblyContainsAttribute || moduleContainsAttribute)
+        if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.Catel.LogMinimalMessageAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.Catel.LogMinimalMessageAttribute"))
         {
             LogMinimalMessage = true;
         }
+        else
+        {
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.Catel.LogMinimalMethodNameAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.Catel.LogMinimalMethodNameAttribute"))
+            {
+                LogMinimalMethodName = true;
+            }
+
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.Catel.DoNotLogMethodNameAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.Catel.DoNotLogMethodNameAttribute"))
+            {
+                DoNotLogMethodName = true;
+            }
+
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.Catel.DoNotLogLineNumberAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.Catel.DoNotLogLineNumberAttribute"))
+            {
+                DoNotLogLineNumber = true;
+            }
+        }
+
         LoadSystemTypes();
         Init();
 

--- a/Catel/Anotar.Catel/DoNotLogLineNumberAttribute.cs
+++ b/Catel/Anotar.Catel/DoNotLogLineNumberAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.Catel
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class DoNotLogLineNumberAttribute : Attribute
+    {
+    }
+}

--- a/Catel/Anotar.Catel/DoNotLogMethodNameAttribute.cs
+++ b/Catel/Anotar.Catel/DoNotLogMethodNameAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.Catel
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class DoNotLogMethodNameAttribute : Attribute
+    {
+    }
+}

--- a/Catel/Anotar.Catel/LogMinimalMethodNameAttribute.cs
+++ b/Catel/Anotar.Catel/LogMinimalMethodNameAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.Catel
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class LogMinimalMethodNameAttribute : Attribute
+    {
+    }
+}

--- a/Common/CecilExtensions.cs
+++ b/Common/CecilExtensions.cs
@@ -33,6 +33,12 @@ public static class CecilExtensions
         return $"{method.ReturnType.DisplayName()} {method.Name}({paramNames})";
     }
 
+    public static string MinimalDisplayName(this MethodDefinition method)
+    {
+        method = GetActualMethod(method);
+        return $"{method.Name}";
+    }
+
     public static string DisplayName(this TypeReference typeReference)
     {
         if (typeReference is GenericInstanceType genericInstanceType && genericInstanceType.HasGenericArguments)

--- a/CommonLogging/Anotar.CommonLogging.Fody/LogForwardingProcessor.cs
+++ b/CommonLogging/Anotar.CommonLogging.Fody/LogForwardingProcessor.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Rocks;
 using Mono.Cecil.Cil;
+using System.Text;
 
 public class LogForwardingProcessor
 {
@@ -255,11 +256,32 @@ public class LogForwardingProcessor
             return string.Empty;
         }
 
-        if (instruction.TryGetPreviousLineNumber(Method, out var lineNumber))
+        var sb = new StringBuilder();
+
+        string methodName = null;
+
+        if (!ModuleWeaver.DoNotLogMethodName)
         {
-            return $"Method: '{Method.DisplayName()}'. Line: ~{lineNumber}. ";
+            if (ModuleWeaver.LogMinimalMethodName)
+            {
+                methodName = Method.MinimalDisplayName();
+            }
+            else
+            {
+                methodName = Method.DisplayName();
+            }
         }
 
-        return $"Method: '{Method.DisplayName()}'. ";
+        if (methodName != null)
+        {
+            sb.Append("Method: '").Append(methodName).Append("'. ");
+        }
+
+        if (!ModuleWeaver.DoNotLogLineNumber && instruction.TryGetPreviousLineNumber(Method, out var lineNumber))
+        {
+            sb.Append("Line: ~").Append(lineNumber).Append(". ");
+        }
+
+        return sb.ToString();
     }
 }

--- a/CommonLogging/Anotar.CommonLogging.Fody/ModuleWeaver.cs
+++ b/CommonLogging/Anotar.CommonLogging.Fody/ModuleWeaver.cs
@@ -5,15 +5,38 @@ using Fody;
 public partial class ModuleWeaver : BaseModuleWeaver
 {
     public bool LogMinimalMessage;
+    public bool LogMinimalMethodName;
+    public bool DoNotLogMethodName;
+    public bool DoNotLogLineNumber;
 
     public override void Execute()
     {
-        var assemblyContainsAttribute = ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.CommonLogging.LogMinimalMessageAttribute");
-        var moduleContainsAttribute = ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.CommonLogging.LogMinimalMessageAttribute");
-        if (assemblyContainsAttribute || moduleContainsAttribute)
+        if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.CommonLogging.LogMinimalMessageAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.CommonLogging.LogMinimalMessageAttribute"))
         {
             LogMinimalMessage = true;
         }
+        else
+        {
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.CommonLogging.LogMinimalMethodNameAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.CommonLogging.LogMinimalMethodNameAttribute"))
+            {
+                LogMinimalMethodName = true;
+            }
+
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.CommonLogging.DoNotLogMethodNameAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.CommonLogging.DoNotLogMethodNameAttribute"))
+            {
+                DoNotLogMethodName = true;
+            }
+
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.CommonLogging.DoNotLogLineNumberAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.CommonLogging.DoNotLogLineNumberAttribute"))
+            {
+                DoNotLogLineNumber = true;
+            }
+        }
+
         LoadSystemTypes();
         Init();
 

--- a/CommonLogging/Anotar.CommonLogging/DoNotLogLineNumberAttribute.cs
+++ b/CommonLogging/Anotar.CommonLogging/DoNotLogLineNumberAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.CommonLogging
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class DoNotLogLineNumberAttribute : Attribute
+    {
+    }
+}

--- a/CommonLogging/Anotar.CommonLogging/DoNotLogMethodNameAttribute.cs
+++ b/CommonLogging/Anotar.CommonLogging/DoNotLogMethodNameAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.CommonLogging
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class DoNotLogMethodNameAttribute : Attribute
+    {
+    }
+}

--- a/CommonLogging/Anotar.CommonLogging/LogMinimalMethodNameAttribute.cs
+++ b/CommonLogging/Anotar.CommonLogging/LogMinimalMethodNameAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.CommonLogging
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class LogMinimalMethodNameAttribute : Attribute
+    {
+    }
+}

--- a/Custom/AssemblyWithLogger/LoggerFactory.cs
+++ b/Custom/AssemblyWithLogger/LoggerFactory.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 // ReSharper disable UnusedTypeParameter
 
-public class LoggerFactory
+public static class LoggerFactory
 {
     public static List<LogEntry> ErrorEntries = new List<LogEntry>();
     public static List<LogEntry> FatalEntries = new List<LogEntry>();

--- a/LibLog/Anotar.LibLog.Fody/LogForwardingProcessor.cs
+++ b/LibLog/Anotar.LibLog.Fody/LogForwardingProcessor.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Rocks;
 using Mono.Cecil.Cil;
+using System.Text;
 
 public class LogForwardingProcessor
 {
@@ -235,11 +236,32 @@ public class LogForwardingProcessor
             return string.Empty;
         }
 
-        if (!instruction.TryGetPreviousLineNumber(Method, out var lineNumber))
+        var sb = new StringBuilder();
+
+        string methodName = null;
+
+        if (!ModuleWeaver.DoNotLogMethodName)
         {
-            return $"Method: '{Method.DisplayName()}'. ";
+            if (ModuleWeaver.LogMinimalMethodName)
+            {
+                methodName = Method.MinimalDisplayName();
+            }
+            else
+            {
+                methodName = Method.DisplayName();
+            }
         }
 
-        return $"Method: '{Method.DisplayName()}'. Line: ~{lineNumber}. ";
+        if (methodName != null)
+        {
+            sb.Append("Method: '").Append(methodName).Append("'. ");
+        }
+
+        if (!ModuleWeaver.DoNotLogLineNumber && instruction.TryGetPreviousLineNumber(Method, out var lineNumber))
+        {
+            sb.Append("Line: ~").Append(lineNumber).Append(". ");
+        }
+
+        return sb.ToString();
     }
 }

--- a/LibLog/Anotar.LibLog.Fody/ModuleWeaver.cs
+++ b/LibLog/Anotar.LibLog.Fody/ModuleWeaver.cs
@@ -5,15 +5,38 @@ using Fody;
 public partial class ModuleWeaver : BaseModuleWeaver
 {
     public bool LogMinimalMessage;
+    public bool LogMinimalMethodName;
+    public bool DoNotLogMethodName;
+    public bool DoNotLogLineNumber;
 
     public override void Execute()
     {
-        var assemblyContainsAttribute = ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.LibLog.LogMinimalMessageAttribute");
-        var moduleContainsAttribute = ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.LibLog.LogMinimalMessageAttribute");
-        if (assemblyContainsAttribute || moduleContainsAttribute)
+        if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.LibLog.LogMinimalMessageAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.LibLog.LogMinimalMessageAttribute"))
         {
             LogMinimalMessage = true;
         }
+        else
+        {
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.LibLog.LogMinimalMethodNameAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.LibLog.LogMinimalMethodNameAttribute"))
+            {
+                LogMinimalMethodName = true;
+            }
+
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.LibLog.DoNotLogMethodNameAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.LibLog.DoNotLogMethodNameAttribute"))
+            {
+                DoNotLogMethodName = true;
+            }
+
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.LibLog.DoNotLogLineNumberAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.LibLog.DoNotLogLineNumberAttribute"))
+            {
+                DoNotLogLineNumber = true;
+            }
+        }
+
         LoadSystemTypes();
 
         Init();

--- a/LibLog/Anotar.LibLog/DoNotLogLineNumberAttribute.cs
+++ b/LibLog/Anotar.LibLog/DoNotLogLineNumberAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.LibLog
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class DoNotLogLineNumberAttribute : Attribute
+    {
+    }
+}

--- a/LibLog/Anotar.LibLog/DoNotLogMethodNameAttribute.cs
+++ b/LibLog/Anotar.LibLog/DoNotLogMethodNameAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.LibLog
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class DoNotLogMethodNameAttribute : Attribute
+    {
+    }
+}

--- a/LibLog/Anotar.LibLog/LogMinimalMethodNameAttribute.cs
+++ b/LibLog/Anotar.LibLog/LogMinimalMethodNameAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.LibLog
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class LogMinimalMethodNameAttribute : Attribute
+    {
+    }
+}

--- a/Log4Net/Anotar.Log4Net.Fody/LogForwardingProcessor.cs
+++ b/Log4Net/Anotar.Log4Net.Fody/LogForwardingProcessor.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Rocks;
 using Mono.Cecil.Cil;
+using System.Text;
 
 public class LogForwardingProcessor
 {
@@ -232,10 +233,32 @@ public class LogForwardingProcessor
             return string.Empty;
         }
 
-        if (instruction.TryGetPreviousLineNumber(Method, out var lineNumber))
+        var sb = new StringBuilder();
+
+        string methodName = null;
+
+        if (!ModuleWeaver.DoNotLogMethodName)
         {
-            return $"Method: '{Method.DisplayName()}'. Line: ~{lineNumber}. ";
+            if (ModuleWeaver.LogMinimalMethodName)
+            {
+                methodName = Method.MinimalDisplayName();
+            }
+            else
+            {
+                methodName = Method.DisplayName();
+            }
         }
-        return $"Method: '{Method.DisplayName()}'. ";
+
+        if (methodName != null)
+        {
+            sb.Append("Method: '").Append(methodName).Append("'. ");
+        }
+
+        if (!ModuleWeaver.DoNotLogLineNumber && instruction.TryGetPreviousLineNumber(Method, out var lineNumber))
+        {
+            sb.Append("Line: ~").Append(lineNumber).Append(". ");
+        }
+
+        return sb.ToString();
     }
 }

--- a/Log4Net/Anotar.Log4Net.Fody/ModuleWeaver.cs
+++ b/Log4Net/Anotar.Log4Net.Fody/ModuleWeaver.cs
@@ -2,18 +2,41 @@
 using System.Linq;
 using Fody;
 
-public partial class ModuleWeaver: BaseModuleWeaver
+public partial class ModuleWeaver : BaseModuleWeaver
 {
     public bool LogMinimalMessage;
+    public bool LogMinimalMethodName;
+    public bool DoNotLogMethodName;
+    public bool DoNotLogLineNumber;
 
     public override void Execute()
     {
-        var assemblyContainsAttribute = ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.Log4Net.LogMinimalMessageAttribute");
-        var moduleContainsAttribute = ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.Log4Net.LogMinimalMessageAttribute");
-        if (assemblyContainsAttribute || moduleContainsAttribute)
+        if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.Log4Net.LogMinimalMessageAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.Log4Net.LogMinimalMessageAttribute"))
         {
             LogMinimalMessage = true;
         }
+        else
+        {
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.Log4Net.LogMinimalMethodNameAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.Log4Net.LogMinimalMethodNameAttribute"))
+            {
+                LogMinimalMethodName = true;
+            }
+
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.Log4Net.DoNotLogMethodNameAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.Log4Net.DoNotLogMethodNameAttribute"))
+            {
+                DoNotLogMethodName = true;
+            }
+
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.Log4Net.DoNotLogLineNumberAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.Log4Net.DoNotLogLineNumberAttribute"))
+            {
+                DoNotLogLineNumber = true;
+            }
+        }
+
         LoadSystemTypes();
         Init();
         foreach (var type in ModuleDefinition

--- a/Log4Net/Anotar.Log4Net/DoNotLogLineNumberAttribute.cs
+++ b/Log4Net/Anotar.Log4Net/DoNotLogLineNumberAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.Log4Net
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class DoNotLogLineNumberAttribute : Attribute
+    {
+    }
+}

--- a/Log4Net/Anotar.Log4Net/DoNotLogMethodNameAttribute.cs
+++ b/Log4Net/Anotar.Log4Net/DoNotLogMethodNameAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.Log4Net
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class DoNotLogMethodNameAttribute : Attribute
+    {
+    }
+}

--- a/Log4Net/Anotar.Log4Net/LogMinimalMethodNameAttribute.cs
+++ b/Log4Net/Anotar.Log4Net/LogMinimalMethodNameAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.Log4Net
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class LogMinimalMethodNameAttribute : Attribute
+    {
+    }
+}

--- a/NLog/Anotar.NLog.Fody/LogForwardingProcessor.cs
+++ b/NLog/Anotar.NLog.Fody/LogForwardingProcessor.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Rocks;
 using Mono.Cecil.Cil;
+using System.Text;
 
 public class LogForwardingProcessor
 {
@@ -232,10 +233,32 @@ public class LogForwardingProcessor
             return string.Empty;
         }
 
-        if (instruction.TryGetPreviousLineNumber(Method, out var lineNumber))
+        var sb = new StringBuilder();
+
+        string methodName = null;
+
+        if (!ModuleWeaver.DoNotLogMethodName)
         {
-            return $"Method: '{Method.DisplayName()}'. Line: ~{lineNumber}. ";
+            if (ModuleWeaver.LogMinimalMethodName)
+            {
+                methodName = Method.MinimalDisplayName();
+            }
+            else
+            {
+                methodName = Method.DisplayName();
+            }
         }
-        return $"Method: '{Method.DisplayName()}'. ";
+
+        if (methodName != null)
+        {
+            sb.Append("Method: '").Append(methodName).Append("'. ");
+        }
+
+        if (!ModuleWeaver.DoNotLogLineNumber && instruction.TryGetPreviousLineNumber(Method, out var lineNumber))
+        {
+            sb.Append("Line: ~").Append(lineNumber).Append(". ");
+        }
+
+        return sb.ToString();
     }
 }

--- a/NLog/Anotar.NLog.Fody/ModuleWeaver.cs
+++ b/NLog/Anotar.NLog.Fody/ModuleWeaver.cs
@@ -5,15 +5,38 @@ using Fody;
 public partial class ModuleWeaver : BaseModuleWeaver
 {
     public bool LogMinimalMessage;
+    public bool LogMinimalMethodName;
+    public bool DoNotLogMethodName;
+    public bool DoNotLogLineNumber;
 
     public override void Execute()
     {
-        var assemblyContainsAttribute = ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.NLog.LogMinimalMessageAttribute");
-        var moduleContainsAttribute = ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.NLog.LogMinimalMessageAttribute");
-        if (assemblyContainsAttribute || moduleContainsAttribute)
+        if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.NLog.LogMinimalMessageAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.NLog.LogMinimalMessageAttribute"))
         {
             LogMinimalMessage = true;
         }
+        else
+        {
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.NLog.LogMinimalMethodNameAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.NLog.LogMinimalMethodNameAttribute"))
+            {
+                LogMinimalMethodName = true;
+            }
+
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.NLog.DoNotLogMethodNameAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.NLog.DoNotLogMethodNameAttribute"))
+            {
+                DoNotLogMethodName = true;
+            }
+
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.NLog.DoNotLogLineNumberAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.NLog.DoNotLogLineNumberAttribute"))
+            {
+                DoNotLogLineNumber = true;
+            }
+        }
+
         LoadSystemTypes();
         Init();
 

--- a/NLog/Anotar.NLog/DoNotLogLineNumberAttribute.cs
+++ b/NLog/Anotar.NLog/DoNotLogLineNumberAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.NLog
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class DoNotLogLineNumberAttribute : Attribute
+    {
+    }
+}

--- a/NLog/Anotar.NLog/DoNotLogMethodNameAttribute.cs
+++ b/NLog/Anotar.NLog/DoNotLogMethodNameAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.NLog
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class DoNotLogMethodNameAttribute : Attribute
+    {
+    }
+}

--- a/NLog/Anotar.NLog/LogMinimalMethodNameAttribute.cs
+++ b/NLog/Anotar.NLog/LogMinimalMethodNameAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.NLog
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class LogMinimalMethodNameAttribute : Attribute
+    {
+    }
+}

--- a/NServiceBus/Anotar.NServiceBus.Fody/LogForwardingProcessor.cs
+++ b/NServiceBus/Anotar.NServiceBus.Fody/LogForwardingProcessor.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Rocks;
 using Mono.Cecil.Cil;
+using System.Text;
 
 public class LogForwardingProcessor
 {
@@ -232,10 +233,32 @@ public class LogForwardingProcessor
             return string.Empty;
         }
 
-        if (instruction.TryGetPreviousLineNumber(Method, out var lineNumber))
+        var sb = new StringBuilder();
+
+        string methodName = null;
+
+        if (!ModuleWeaver.DoNotLogMethodName)
         {
-            return $"Method: '{Method.DisplayName()}'. Line: ~{lineNumber}. ";
+            if (ModuleWeaver.LogMinimalMethodName)
+            {
+                methodName = Method.MinimalDisplayName();
+            }
+            else
+            {
+                methodName = Method.DisplayName();
+            }
         }
-        return $"Method: '{Method.DisplayName()}'. ";
+
+        if (methodName != null)
+        {
+            sb.Append("Method: '").Append(methodName).Append("'. ");
+        }
+
+        if (!ModuleWeaver.DoNotLogLineNumber && instruction.TryGetPreviousLineNumber(Method, out var lineNumber))
+        {
+            sb.Append("Line: ~").Append(lineNumber).Append(". ");
+        }
+
+        return sb.ToString();
     }
 }

--- a/NServiceBus/Anotar.NServiceBus.Fody/ModuleWeaver.cs
+++ b/NServiceBus/Anotar.NServiceBus.Fody/ModuleWeaver.cs
@@ -5,15 +5,38 @@ using Fody;
 public partial class ModuleWeaver : BaseModuleWeaver
 {
     public bool LogMinimalMessage;
+    public bool LogMinimalMethodName;
+    public bool DoNotLogMethodName;
+    public bool DoNotLogLineNumber;
 
     public override void Execute()
     {
-        var assemblyContainsAttribute = ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.NServiceBus.LogMinimalMessageAttribute");
-        var moduleContainsAttribute = ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.NServiceBus.LogMinimalMessageAttribute");
-        if (assemblyContainsAttribute || moduleContainsAttribute)
+        if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.NServiceBus.LogMinimalMessageAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.NServiceBus.LogMinimalMessageAttribute"))
         {
             LogMinimalMessage = true;
         }
+        else
+        {
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.NServiceBus.LogMinimalMethodNameAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.NServiceBus.LogMinimalMethodNameAttribute"))
+            {
+                LogMinimalMethodName = true;
+            }
+
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.NServiceBus.DoNotLogMethodNameAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.NServiceBus.DoNotLogMethodNameAttribute"))
+            {
+                DoNotLogMethodName = true;
+            }
+
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.NServiceBus.DoNotLogLineNumberAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.NServiceBus.DoNotLogLineNumberAttribute"))
+            {
+                DoNotLogLineNumber = true;
+            }
+        }
+
         LoadSystemTypes();
         Init();
 

--- a/NServiceBus/Anotar.NServiceBus/DoNotLogLineNumberAttribute.cs
+++ b/NServiceBus/Anotar.NServiceBus/DoNotLogLineNumberAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.NServiceBus
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class DoNotLogLineNumberAttribute : Attribute
+    {
+    }
+}

--- a/NServiceBus/Anotar.NServiceBus/DoNotLogMethodNameAttribute.cs
+++ b/NServiceBus/Anotar.NServiceBus/DoNotLogMethodNameAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.NServiceBus
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class DoNotLogMethodNameAttribute : Attribute
+    {
+    }
+}

--- a/NServiceBus/Anotar.NServiceBus/LogMinimalMethodNameAttribute.cs
+++ b/NServiceBus/Anotar.NServiceBus/LogMinimalMethodNameAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.NServiceBus
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class LogMinimalMethodNameAttribute : Attribute
+    {
+    }
+}

--- a/Serilog/Anotar.Serilog.Fody/LogForwardingProcessor.cs
+++ b/Serilog/Anotar.Serilog.Fody/LogForwardingProcessor.cs
@@ -177,8 +177,21 @@ public class LogForwardingProcessor
     {
         //add logger to stack
         replacement.Append(Instruction.Create(OpCodes.Ldsfld, LoggerField));
-        AppendMethodName(replacement);
-        AppendLineNumber(instruction, replacement);
+
+        if (ModuleWeaver.LogMinimalMessage)
+        {
+            return;
+        }
+
+        if (!ModuleWeaver.DoNotLogMethodName)
+        {
+            AppendMethodName(replacement);
+        }
+
+        if (!ModuleWeaver.DoNotLogLineNumber)
+        {
+            AppendLineNumber(instruction, replacement);
+        }
     }
 
     void HandleNoParams(Instruction instruction, MethodReference methodReference)

--- a/Serilog/Anotar.Serilog.Fody/ModuleWeaver.cs
+++ b/Serilog/Anotar.Serilog.Fody/ModuleWeaver.cs
@@ -4,8 +4,39 @@ using Fody;
 
 public partial class ModuleWeaver: BaseModuleWeaver
 {
+    public bool LogMinimalMessage;
+    public bool LogMinimalMethodName;
+    public bool DoNotLogMethodName;
+    public bool DoNotLogLineNumber;
+
     public override void Execute()
     {
+        if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.Serilog.LogMinimalMessageAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.Serilog.LogMinimalMessageAttribute"))
+        {
+            LogMinimalMessage = true;
+        }
+        else
+        {
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.Serilog.LogMinimalMethodNameAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.Serilog.LogMinimalMethodNameAttribute"))
+            {
+                LogMinimalMethodName = true;
+            }
+
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.Serilog.DoNotLogMethodNameAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.Serilog.DoNotLogMethodNameAttribute"))
+            {
+                DoNotLogMethodName = true;
+            }
+
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.Serilog.DoNotLogLineNumberAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.Serilog.DoNotLogLineNumberAttribute"))
+            {
+                DoNotLogLineNumber = true;
+            }
+        }
+
         LoadSystemTypes();
         Init();
         foreach (var type in ModuleDefinition

--- a/Serilog/Anotar.Serilog/DoNotLogLineNumberAttribute.cs
+++ b/Serilog/Anotar.Serilog/DoNotLogLineNumberAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.Serilog
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class DoNotLogLineNumberAttribute : Attribute
+    {
+    }
+}

--- a/Serilog/Anotar.Serilog/DoNotLogMethodNameAttribute.cs
+++ b/Serilog/Anotar.Serilog/DoNotLogMethodNameAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.Serilog
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class DoNotLogMethodNameAttribute : Attribute
+    {
+    }
+}

--- a/Serilog/Anotar.Serilog/LogMinimalMethodNameAttribute.cs
+++ b/Serilog/Anotar.Serilog/LogMinimalMethodNameAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.Serilog
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class LogMinimalMethodNameAttribute : Attribute
+    {
+    }
+}

--- a/Serilog/AssemblyToProcess/ClassWithStaticConstructor.cs
+++ b/Serilog/AssemblyToProcess/ClassWithStaticConstructor.cs
@@ -5,7 +5,7 @@ using Serilog.Core;
 using Serilog.Events;
 using Log = Serilog.Log;
 
-public class ClassWithStaticConstructor
+public static class ClassWithStaticConstructor
 {
     public static string Message;
     public class EventSink : ILogEventSink

--- a/Splat/Anotar.Splat.Fody/LogForwardingProcessor.cs
+++ b/Splat/Anotar.Splat.Fody/LogForwardingProcessor.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Rocks;
 using Mono.Cecil.Cil;
+using System.Text;
 
 public class LogForwardingProcessor
 {
@@ -234,10 +235,32 @@ public class LogForwardingProcessor
             return string.Empty;
         }
 
-        if (instruction.TryGetPreviousLineNumber(Method, out var lineNumber))
+        var sb = new StringBuilder();
+
+        string methodName = null;
+
+        if (!ModuleWeaver.DoNotLogMethodName)
         {
-            return $"Method: '{Method.DisplayName()}'. Line: ~{lineNumber}. ";
+            if (ModuleWeaver.LogMinimalMethodName)
+            {
+                methodName = Method.MinimalDisplayName();
+            }
+            else
+            {
+                methodName = Method.DisplayName();
+            }
         }
-        return $"Method: '{Method.DisplayName()}'. ";
+
+        if (methodName != null)
+        {
+            sb.Append("Method: '").Append(methodName).Append("'. ");
+        }
+
+        if (!ModuleWeaver.DoNotLogLineNumber && instruction.TryGetPreviousLineNumber(Method, out var lineNumber))
+        {
+            sb.Append("Line: ~").Append(lineNumber).Append(". ");
+        }
+
+        return sb.ToString();
     }
 }

--- a/Splat/Anotar.Splat.Fody/ModuleWeaver.cs
+++ b/Splat/Anotar.Splat.Fody/ModuleWeaver.cs
@@ -5,15 +5,38 @@ using Fody;
 public partial class ModuleWeaver : BaseModuleWeaver
 {
     public bool LogMinimalMessage;
+    public bool LogMinimalMethodName;
+    public bool DoNotLogMethodName;
+    public bool DoNotLogLineNumber;
 
     public override void Execute()
     {
-        var assemblyContainsAttribute = ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.Splat.LogMinimalMessageAttribute");
-        var moduleContainsAttribute = ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.Splat.LogMinimalMessageAttribute");
-        if (assemblyContainsAttribute || moduleContainsAttribute)
+        if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.Splat.LogMinimalMessageAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.Splat.LogMinimalMessageAttribute"))
         {
             LogMinimalMessage = true;
         }
+        else
+        {
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.Splat.LogMinimalMethodNameAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.Splat.LogMinimalMethodNameAttribute"))
+            {
+                LogMinimalMethodName = true;
+            }
+
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.Splat.DoNotLogMethodNameAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.Splat.DoNotLogMethodNameAttribute"))
+            {
+                DoNotLogMethodName = true;
+            }
+
+            if (ModuleDefinition.Assembly.CustomAttributes.ContainsAttribute("Anotar.Splat.DoNotLogLineNumberAttribute")
+            || ModuleDefinition.CustomAttributes.ContainsAttribute("Anotar.Splat.DoNotLogLineNumberAttribute"))
+            {
+                DoNotLogLineNumber = true;
+            }
+        }
+
         LoadSystemTypes();
         Init();
         foreach (var type in ModuleDefinition

--- a/Splat/Anotar.Splat/DoNotLogLineNumberAttribute.cs
+++ b/Splat/Anotar.Splat/DoNotLogLineNumberAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.Splat
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class DoNotLogLineNumberAttribute : Attribute
+    {
+    }
+}

--- a/Splat/Anotar.Splat/DoNotLogMethodNameAttribute.cs
+++ b/Splat/Anotar.Splat/DoNotLogMethodNameAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.Splat
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class DoNotLogMethodNameAttribute : Attribute
+    {
+    }
+}

--- a/Splat/Anotar.Splat/LogMinimalMethodNameAttribute.cs
+++ b/Splat/Anotar.Splat/LogMinimalMethodNameAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Anotar.Splat
+{
+    /// <summary>
+    /// Used to suppress message prefixing.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Module)]
+    public class LogMinimalMethodNameAttribute : Attribute
+    {
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -457,9 +457,87 @@ Often when I am logging I want to know the method and line number I am logging f
 
 ## I don't want extra information
 
-If you don't want the extra information, method name and line number, then add this to `AssemblyInfo.cs`:
+You can remove method name or line number by defining the following attributes accordingly in `AssemblyInfo.cs`:
+
+```c#
+[assembly: DoNotLogMethodName]
+[assembly: DoNotLogLineNumber]
+```
+
+### What gets compiled
+
+When you define `DoNotLogMethodName` attribute
+
+#### In Catel
+
+```c#
+public class MyClass
+{
+    static ILog logger = LogManager.GetLogger(typeof(MyClass));
+
+    void MyMethod()
+    {
+        logger.WriteWithData("Line: ~12. TheMessage", null, LogEvent.Debug);
+    }
+}
+
+```
+
+When you define `DoNotLogLineNumber` attribute
+
+#### In Log4Net
+
+```c#
+public class MyClass
+{
+    static ILog logger = LogManager.GetLogger("MyClass");
+
+    void MyMethod()
+    {
+        logger.Debug("Method: 'Void MyMethod()'. TheMessage");
+    }
+}
+```
+
+If you just want to log the method name but in a more minimal way instead (eg. Void MyMethod() => MyMethod) you can define the following assembly attribute in `AssemblyInfo.cs`:
+
+     [assembly: LogMinimalMethodName]
+
+### What gets compiled
+
+#### In NLog
+
+```c#
+public class MyClass
+{
+    static Logger logger = LogManager.GetLogger("MyClass");
+
+    void MyMethod()
+    {
+        logger.Debug("Method: 'MyMethod'. Line: ~12. TheMessage");
+    }
+}
+```
+
+If you just don't want the extra information, method name and line number, then add this to `AssemblyInfo.cs`:
 
     [assembly: LogMinimalMessage]
+
+### What gets compiled
+
+#### In NServiceBus
+
+```c#
+public class MyClass
+{
+    static ILog logger = LogManager.GetLogger("MyClass");
+
+    void MyMethod()
+    {
+        logger.DebugFormat("TheMessage");
+    }
+}
+```
 
 
 ## Why not use CallerInfoAttributes


### PR DESCRIPTION
### Description

Add `LogMinimalMethodName`, `DoNotLogMethodName`, `DoNotLogLineNumber` Attributes. Enables further more configuration to customize the log messages

### The solution

Introduced `LogMinimalMethodName`, `DoNotLogMethodName`, `DoNotLogLineNumber` Attributes which can be defined in `AssemblyInfo.cs`. 

### Attached from readme.md

You can remove method name or line number by defining the following attributes accordingly in `AssemblyInfo.cs`:

```c#
[assembly: DoNotLogMethodName]
[assembly: DoNotLogLineNumber]
```

#### What gets compiled

When you define `DoNotLogMethodName` attribute

##### In Catel

```c#
public class MyClass
{
    static ILog logger = LogManager.GetLogger(typeof(MyClass));

    void MyMethod()
    {
        logger.WriteWithData("Line: ~12. TheMessage", null, LogEvent.Debug);
    }
}

```

When you define `DoNotLogLineNumber` attribute

##### In Log4Net

```c#
public class MyClass
{
    static ILog logger = LogManager.GetLogger("MyClass");

    void MyMethod()
    {
        logger.Debug("Method: 'Void MyMethod()'. TheMessage");
    }
}
```

If you just want to log the method name but in a more minimal way instead (eg. Void MyMethod() => MyMethod) you can define the following assembly attribute in `AssemblyInfo.cs`:

     [assembly: LogMinimalMethodName]

#### What gets compiled

##### In NLog

```c#
public class MyClass
{
    static Logger logger = LogManager.GetLogger("MyClass");

    void MyMethod()
    {
        logger.Debug("Method: 'MyMethod'. Line: ~12. TheMessage");
    }
}
```


#### Todos

 * [ ] Tests
 * [x] Documentation